### PR TITLE
Added defaulting to Tango icon theme

### DIFF
--- a/qt_gui/manifest.xml
+++ b/qt_gui/manifest.xml
@@ -11,6 +11,7 @@
 
   <depend package="python_qt_binding"/>
   <rosdep name="python-qt-bindings"/>
+  <rosdep name="tango-icon-theme"/>
 </package>
 
 

--- a/qt_gui/src/qt_gui/main.py
+++ b/qt_gui/src/qt_gui/main.py
@@ -116,8 +116,7 @@ class Main(object):
     def _check_icon_theme_compliance(self):
         from python_qt_binding.QtGui import QIcon
         if QIcon.themeName == '' or QIcon.fromTheme('document-save').isNull() or QIcon.fromTheme('document-open').isNull() or QIcon.fromTheme('edit-cut').isNull() or QIcon.fromTheme('object-flip-horizontal').isNull():
-            QIcon.setThemeName('gnome')
-            QIcon.setThemeSearchPaths(QIcon.themeSearchPaths() + [os.path.realpath(os.path.join(os.path.dirname(__file__), '..', '..', 'icons', ''))])
+            QIcon.setThemeName('Tango')
 
     def main(self, argv=None):
         # check if DBus is available


### PR DESCRIPTION
When key icons are missing the Tango opensource icon set is used instead.
