### PR TITLE
Use parser.parse_known_args() to ignore unknown/ROS arguments

### DIFF
--- a/qt_gui/src/qt_gui/main.py
+++ b/qt_gui/src/qt_gui/main.py
@@ -147,8 +147,12 @@ class Main(object):
             arguments = arguments[0:index + 1]
         parser = ArgumentParser('usage: %prog [options]')
         self._add_arguments(parser)
-        self._options = parser.parse_args(arguments)
+        self._options, unknown_args = parser.parse_known_args(arguments)
         self._options.args = args
+
+        # report unknown arguments
+        for arg in unknown_args:
+            print('Unknown argument: "%s"' % arg)
 
         # check option dependencies
         try:


### PR DESCRIPTION
This small commit replaces the parse_args() call with a parse_known_args(). This allows the user to pass invalid arguments, without raising exceptions.

The reason for this commit is as follows:
rqt is going to be the base for various tools within the ROS environment. But, at the moment it seems to be impossible to load rqt_gui from a launch file. This seems to come from roslaunch adding the arguments "__name:=..." and "__log:=..." for each node. These arguments aren't known to qt_gui_core and rqt_gui, and make them fail with an error.

A possible solution would be to filter the arguments within rqt_gui. This could happen with ros::removeROSArgs(), but this seems to be quite messy.
I think currently it's a better solution to completely ignore invalid argument and those introduced by ROS, while printing a warning.

See: http://docs.python.org/dev/library/argparse.html#argparse.ArgumentParser.parse_known_args
