### PR TITLE
Add /usr/local/share/icons to icon search path for OS X

### DIFF
--- a/qt_gui/src/qt_gui/main.py
+++ b/qt_gui/src/qt_gui/main.py
@@ -154,6 +154,8 @@ class Main(object):
            QIcon.fromTheme('document-open').isNull() or \
            QIcon.fromTheme('edit-cut').isNull() or \
            QIcon.fromTheme('object-flip-horizontal').isNull():
+            if 'darwin' in platform.platform().lower() and '/usr/local/share/icons' not in QIcon.themeSearchPaths():
+                QIcon.setThemeSearchPaths(QIcon.themeSearchPaths() + ['/usr/local/share/icons'])
             original_theme = QIcon.themeName()
             QIcon.setThemeName('Tango')
             if QIcon.fromTheme('document-save').isNull():


### PR DESCRIPTION
This is needed when installing tango-icon-theme on OS X
