### PR TITLE
disable shiboken when version is detected which would segfault (fix #35)

### DIFF
--- a/qt_gui_cpp/src/qt_gui_cpp_shiboken/CMakeLists.txt
+++ b/qt_gui_cpp/src/qt_gui_cpp_shiboken/CMakeLists.txt
@@ -41,22 +41,27 @@ find_package(python_qt_binding REQUIRED)
 include(${python_qt_binding_EXTRAS_DIR}/shiboken_helper.cmake)
 
 if(shiboken_helper_FOUND)
-  list(APPEND qt_gui_cpp_BINDINGS "shiboken")
-  set(qt_gui_cpp_BINDINGS "${qt_gui_cpp_BINDINGS}" PARENT_SCOPE)
+  if(Shiboken_VERSION VERSION_GREATER "1.1.1")
+    # shiboken 1.1.2 and higher will segfault until https://bugreports.qt-project.org/browse/PYSIDE-218 is fixed
+    message(WARNING "Shiboken version ${Shiboken_VERSION} would segfault when trying to process qt_gui_cpp (see https://bugreports.qt-project.org/browse/PYSIDE-218). Therefore shiboken bindings are being skipped.")
+  else()
+    list(APPEND qt_gui_cpp_BINDINGS "shiboken")
+    set(qt_gui_cpp_BINDINGS "${qt_gui_cpp_BINDINGS}" PARENT_SCOPE)
 
-  shiboken_generator(libqt_gui_cpp global.h typesystem.xml ${PROJECT_SOURCE_DIR}/src/qt_gui_cpp_shiboken "${qt_gui_cpp_shiboken_SRCS}" "${qt_gui_cpp_HDRS}" "${qt_gui_cpp_INCLUDE_PATH}" "${CMAKE_CURRENT_BINARY_DIR}")
+    shiboken_generator(libqt_gui_cpp global.h typesystem.xml ${PROJECT_SOURCE_DIR}/src/qt_gui_cpp_shiboken "${qt_gui_cpp_shiboken_SRCS}" "${qt_gui_cpp_HDRS}" "${qt_gui_cpp_INCLUDE_PATH}" "${CMAKE_CURRENT_BINARY_DIR}")
 
-  include_directories(qt_gui_cpp_shiboken ${qt_gui_cpp_INCLUDE_PATH}/qt_gui_cpp)
-  shiboken_include_directories(qt_gui_cpp_shiboken "${qt_gui_cpp_shiboken_QT_COMPONENTS}")
-  add_library(qt_gui_cpp_shiboken ${qt_gui_cpp_shiboken_SRCS})
-  set_target_properties(qt_gui_cpp_shiboken PROPERTIES
-    ARCHIVE_OUTPUT_DIRECTORY ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_PYTHON_DESTINATION}
-    LIBRARY_OUTPUT_DIRECTORY ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_PYTHON_DESTINATION}
-  )
-  target_link_libraries(qt_gui_cpp_shiboken ${PROJECT_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
-  shiboken_target_link_libraries(qt_gui_cpp_shiboken "${qt_gui_cpp_shiboken_QT_COMPONENTS}")
+    include_directories(qt_gui_cpp_shiboken ${qt_gui_cpp_INCLUDE_PATH}/qt_gui_cpp)
+    shiboken_include_directories(qt_gui_cpp_shiboken "${qt_gui_cpp_shiboken_QT_COMPONENTS}")
+    add_library(qt_gui_cpp_shiboken ${qt_gui_cpp_shiboken_SRCS})
+    set_target_properties(qt_gui_cpp_shiboken PROPERTIES
+      ARCHIVE_OUTPUT_DIRECTORY ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_PYTHON_DESTINATION}
+      LIBRARY_OUTPUT_DIRECTORY ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_PYTHON_DESTINATION}
+    )
+    target_link_libraries(qt_gui_cpp_shiboken ${PROJECT_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+    shiboken_target_link_libraries(qt_gui_cpp_shiboken "${qt_gui_cpp_shiboken_QT_COMPONENTS}")
 
-  install(TARGETS qt_gui_cpp_shiboken
-    ARCHIVE DESTINATION ${CATKIN_PACKAGE_PYTHON_DESTINATION}
-    LIBRARY DESTINATION ${CATKIN_PACKAGE_PYTHON_DESTINATION})
+    install(TARGETS qt_gui_cpp_shiboken
+      ARCHIVE DESTINATION ${CATKIN_PACKAGE_PYTHON_DESTINATION}
+      LIBRARY DESTINATION ${CATKIN_PACKAGE_PYTHON_DESTINATION})
+  endif()
 endif()


### PR DESCRIPTION
This should only be a temporary workaround since it will disable shiboken for any newer version.

@tfoote @wjwwood Please review.
