### PR TITLE
fix crash in rqt_dep

### DIFF
--- a/qt_dotgraph/src/qt_dotgraph/pydotfactory.py
+++ b/qt_dotgraph/src/qt_dotgraph/pydotfactory.py
@@ -94,7 +94,7 @@ class PydotFactory():
         if url is not None:
             node.set_URL(self.escape_name(url))
         if color is not None:
-            node.set_node_color(color)
+            node.set_color(color)
         graph.add_node(node)
 
     def add_subgraph_to_graph(self,


### PR DESCRIPTION
This fixes an old bad search/replace: set_color was renamed for this qt_dotgraph objects, but on that line it's a normal Pydot object.
