### PR TITLE
Test improvements

### DIFF
--- a/qt_dotgraph/CMakeLists.txt
+++ b/qt_dotgraph/CMakeLists.txt
@@ -6,4 +6,6 @@ catkin_package()
 
 catkin_python_setup()
 
-catkin_add_nosetests(test)
+if (CATKIN_ENABLE_TESTING)
+  catkin_add_nosetests(test)
+endif()

--- a/qt_dotgraph/package.xml
+++ b/qt_dotgraph/package.xml
@@ -16,4 +16,6 @@
 
   <run_depend>python-pydot</run_depend>
   <run_depend>python_qt_binding</run_depend>
+
+  <test_depend>python-pygraphviz</test_depend>
 </package>

--- a/qt_dotgraph/test/pydot_factory_test.py
+++ b/qt_dotgraph/test/pydot_factory_test.py
@@ -57,7 +57,7 @@ class PyDotFactoryTest(unittest.TestCase):
         self.assertEqual(1, len(g.get_nodes()))
         self.assertEqual('graph_', g.get_nodes()[0].get_name())
         self.assertEqual('graph_', g.get_nodes()[0].get_label())
-        
+
     def test_add_edge(self):
         fac = PydotFactory()
         g = fac.get_graph()
@@ -92,10 +92,19 @@ class PyDotFactoryTest(unittest.TestCase):
         fac.add_node_to_graph(g, 'edge')
         fac.add_edge_to_graph(g, 'foo', 'edge')
         fac.add_subgraph_to_graph(g, 'foo')
-        snippets = ['digraph graphname {\n\tgraph [rankdir=TB, rank=same];\n\tnode [label="\\N"];\n\tgraph [bb="', '"];\n\tsubgraph cluster_foo {\n\t\tgraph [',
-                    '];\n\t}\n\tfoo [label=foo, shape=box, pos="',
-                    'edge_ [label=edge_, shape=box, pos="',
-                    'foo -> edge_',
+        snippets = ['digraph graphname {\n\tgraph [',
+                    'rankdir=TB',
+                    'compound=True',
+                    'rank=same',
+                    'node [label="\\N"]',
+                    'subgraph cluster_foo {\n\t\tgraph [',
+                    'foo\t [',
+                    'label=foo',
+                    'shape=box',
+                    'pos="',
+                    'edge_\t [',
+                    'label=edge_',
+                    'foo -> edge_\t [',
                     '"];\n}\n']
         result = fac.create_dot(g)
         for sn in snippets:


### PR DESCRIPTION
Add python-pygraphviz as test_depend for qt_dotgraph. Shouldn't it be rather included as run_depend for the pygraphvizfactory module to work out-of-the box for potential users?

Add condition around catkin_add_nosetests

Fix PyDotFactoryTest.test_create_dot