### PR TITLE
Added X11 threading for ssh display

### DIFF
--- a/qt_gui/src/qt_gui/main.py
+++ b/qt_gui/src/qt_gui/main.py
@@ -170,6 +170,7 @@ class Main(object):
     def create_application(self, argv):
         from python_qt_binding.QtCore import Qt
         from python_qt_binding.QtGui import QApplication
+        QApplication.setAttribute(Qt.AA_X11InitThreads, True)
         app = QApplication(argv)
         app.setAttribute(Qt.AA_DontShowIconsInMenus, False)
         return app


### PR DESCRIPTION
When trying to run ROS rqt tools through a PuTTY ssh connection, the rqt tools crash.  More information can be found on ROS answers [here](http://answers.ros.org/question/208445/error-using-rqt-with-xming-69031-through-putty/).