### PR TITLE
Fixing unhandled errors when starting rqt without roscore 

### DIFF
--- a/qt_gui/src/qt_gui/plugin_handler.py
+++ b/qt_gui/src/qt_gui/plugin_handler.py
@@ -109,7 +109,7 @@ class PluginHandler(QObject):
         if self.__callback is not None:
             callback = self.__callback
             self.__callback = None
-            callback(self, exception)
+            callback(self)
         elif exception is not None:
             qCritical('PluginHandler.load() failed%s' % (':\n%s' % str(exception) if exception != True else ''))
 

--- a/qt_gui/src/qt_gui/plugin_handler.py
+++ b/qt_gui/src/qt_gui/plugin_handler.py
@@ -109,7 +109,10 @@ class PluginHandler(QObject):
         if self.__callback is not None:
             callback = self.__callback
             self.__callback = None
-            callback(self)
+            try:
+                callback(self, exception)
+            except TypeError:
+                qDebug('PluginHandler._emit_load_completed({0})'.format(exception))
         elif exception is not None:
             qCritical('PluginHandler.load() failed%s' % (':\n%s' % str(exception) if exception != True else ''))
 

--- a/qt_gui/src/qt_gui/plugin_handler_direct.py
+++ b/qt_gui/src/qt_gui/plugin_handler_direct.py
@@ -104,9 +104,9 @@ class PluginHandlerDirect(PluginHandler):
             instance_settings_plugin = instance_settings.get_settings('plugin')
             try:
                 self._plugin.save_settings(plugin_settings_plugin, instance_settings_plugin)
+                self.emit_save_settings_completed()
             except Exception:
                 qCritical('PluginHandlerDirect._save_settings() plugin "%s" raised an exception:\n%s' % (str(self._instance_id), traceback.format_exc()))
-        self.emit_save_settings_completed()
 
     def _restore_settings(self, plugin_settings, instance_settings):
         if hasattr(self._plugin, 'restore_settings'):
@@ -114,9 +114,9 @@ class PluginHandlerDirect(PluginHandler):
             instance_settings_plugin = instance_settings.get_settings('plugin')
             try:
                 self._plugin.restore_settings(plugin_settings_plugin, instance_settings_plugin)
+                self.emit_restore_settings_completed()
             except Exception:
                 qCritical('PluginHandlerDirect._restore_settings() plugin "%s" raised an exception:\n%s' % (str(self._instance_id), traceback.format_exc()))
-        self.emit_restore_settings_completed()
 
     # pointer to QWidget must be used for PySide to work (at least with 1.0.1)
     @Slot('QWidget*')

--- a/qt_gui/src/qt_gui/plugin_manager.py
+++ b/qt_gui/src/qt_gui/plugin_manager.py
@@ -318,8 +318,11 @@ class PluginManager(QObject):
         # shutdown plugin before unloading
         info = self._running_plugins[str(instance_id)]
         handler = info['handler']
-        handler.close_signal.disconnect(self.unload_plugin)
-        handler.shutdown_plugin(callback)
+        try:
+            handler.close_signal.disconnect(self.unload_plugin)
+            handler.shutdown_plugin(callback)
+        except TypeError:
+            qDebug('PluginManager._shutdown_plugin({0}, {1})'.format(instance_id, callback))
 
     def _unload_plugin_unload(self, instance_id):
         qDebug('PluginManager._unload_plugin_unload(%s)' % str(instance_id))


### PR DESCRIPTION
Sorry for the unprecise title. It refers to the way I triggered the errors.

The errors arises when you open rqt without having the rosmaster running.
And also when you hit Ctrl+C before clicking Abort in the DialogBox telling you about the not running rosmaster.

From my view unhandled errors are always something you don't want on your console no matter what.

To fix this I moved calls into try blocks and reduced the parameters for the callback within the  __emit_load_completed_ function due to not matching signatures.

Hopefully this breaks nothing in this big package that I missed.