### PR TITLE
use Python 3 compatible syntax

### DIFF
--- a/qt_dotgraph/src/qt_dotgraph/dot_to_qt.py
+++ b/qt_dotgraph/src/qt_dotgraph/dot_to_qt.py
@@ -68,7 +68,7 @@ class DotToQtGenerator():
     def getNodeItemForSubgraph(self, subgraph, highlight_level):
         # let pydot imitate pygraphviz api
         attr = {}
-        for name in subgraph.get_attributes().iterkeys():
+        for name in subgraph.get_attributes().keys():
             value = get_unquoted(subgraph, name)
             attr[name] = value
         obj_dic = subgraph.__getattribute__("obj_dict")
@@ -117,7 +117,7 @@ class DotToQtGenerator():
         """
         # let pydot imitate pygraphviz api
         attr = {}
-        for name in node.get_attributes().iterkeys():
+        for name in node.get_attributes().keys():
             value = get_unquoted(node, name)
             attr[name] = value
         obj_dic = node.__getattribute__("obj_dict")
@@ -162,7 +162,7 @@ class DotToQtGenerator():
         """
         # let pydot imitate pygraphviz api
         attr = {}
-        for name in edge.get_attributes().iterkeys():
+        for name in edge.get_attributes().keys():
             value = get_unquoted(edge, name)
             attr[name] = value
         edge.attr = attr

--- a/qt_dotgraph/src/qt_dotgraph/pydotfactory.py
+++ b/qt_dotgraph/src/qt_dotgraph/pydotfactory.py
@@ -31,7 +31,10 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 from distutils.version import LooseVersion
-import urllib
+try:
+    from urllib.request import quote
+except ImportError:
+    from urllib import quote
 
 # work around for https://bugs.launchpad.net/ubuntu/+source/pydot/+bug/1321135
 import pyparsing
@@ -53,7 +56,7 @@ class PydotFactory():
         return ret
 
     def escape_name(self, name):
-        ret = urllib.quote(name.strip())
+        ret = quote(name.strip())
         ret = ret.replace('/', '_')
         ret = ret.replace('%', '_')
         ret = ret.replace('-', '_')

--- a/qt_gui/src/qt_gui/dock_widget.py
+++ b/qt_gui/src/qt_gui/dock_widget.py
@@ -169,7 +169,7 @@ class DockWidget(QDockWidget):
             elif len(overlapping) > 1:
                 # try to determine which main window is the right one
                 # determined docked main windows
-                overlapping_docked = [mw for mw, floating in overlapping.iteritems() if not floating]
+                overlapping_docked = [mw for mw, floating in overlapping.items() if not floating]
                 #print 'overlapping_docked', overlapping_docked
 
                 # if at max one of the main windows is floating

--- a/qt_gui/src/qt_gui/perspective_manager.py
+++ b/qt_gui/src/qt_gui/perspective_manager.py
@@ -41,11 +41,19 @@ from .settings import Settings
 from .settings_proxy import SettingsProxy
 
 
+def is_string(s):
+    """Check if the argument is a string which works for both Python 2 and 3."""
+    try:
+        return isinstance(s, basestring)
+    except NameError:
+        return isinstance(s, str)
+
+
 class PerspectiveManager(QObject):
 
     """Manager for perspectives associated with specific sets of `Settings`."""
 
-    perspective_changed_signal = Signal(basestring)
+    perspective_changed_signal = Signal(str)
     save_settings_signal = Signal(Settings, Settings)
     restore_settings_signal = Signal(Settings, Settings)
     restore_settings_without_plugin_changes_signal = Signal(Settings, Settings)
@@ -68,7 +76,7 @@ class PerspectiveManager(QObject):
 
         # get perspective list from settings
         self.perspectives = self._settings_proxy.value('', 'perspectives', [])
-        if isinstance(self.perspectives, basestring):
+        if is_string(self.perspectives):
             self.perspectives = [self.perspectives]
 
         self._current_perspective = None

--- a/qt_gui/src/qt_gui/plugin_handler.py
+++ b/qt_gui/src/qt_gui/plugin_handler.py
@@ -114,10 +114,10 @@ class PluginHandler(QObject):
             qCritical('PluginHandler.load() failed%s' % (':\n%s' % str(exception) if exception != True else ''))
 
     def _garbage_widgets_and_toolbars(self):
-        for widget in self._widgets.keys():
+        for widget in list(self._widgets.keys()):
             self.remove_widget(widget)
             self._delete_widget(widget)
-        for toolbar in self._toolbars:
+        for toolbar in list(self._toolbars):
             self.remove_toolbar(toolbar)
             self._delete_toolbar(toolbar)
 
@@ -282,7 +282,7 @@ class PluginHandler(QObject):
                 title_bar.show_button('configuration')
 
     def _remove_widget_by_dock_widget(self, dock_widget):
-        widget = [key for key, value in self._widgets.iteritems() if value[0] == dock_widget][0]
+        widget = [key for key, value in self._widgets.items() if value[0] == dock_widget][0]
         self.remove_widget(widget)
 
     def _emit_help_signal(self):

--- a/qt_gui/src/qt_gui/settings_proxy_dbus_service.py
+++ b/qt_gui/src/qt_gui/settings_proxy_dbus_service.py
@@ -88,5 +88,8 @@ class SettingsProxyDBusService(dbus.service.Object):
         elif isinstance(value, dbus.String):
             value = str(value)
         elif isinstance(value, dbus.UTF8String):
-            value = unicode(value)
+            try:
+                value = unicode(value)
+            except NameError:
+                value = str(value)
         return value

--- a/qt_gui_py_common/src/qt_gui_py_common/console_text_edit.py
+++ b/qt_gui_py_common/src/qt_gui_py_common/console_text_edit.py
@@ -90,7 +90,7 @@ class ConsoleTextEdit(QTextEdit):
             return None
         else:
             # should have a better way of doing this but I can't find it
-            for _ in xrange(length):
+            for _ in range(length):
                 self.textCursor().deletePreviousChar()
         return True
 


### PR DESCRIPTION
While this patch doesn't guarantee that Python 3 works all the way it at last uses Python 3 compatible syntax and addresses obvious problems starting `rqt` and its plugins.