### PR TITLE
Use file name for rqt window title when loading a .perspective

### DIFF
--- a/qt_gui/src/qt_gui/main.py
+++ b/qt_gui/src/qt_gui/main.py
@@ -520,7 +520,7 @@ class Main(object):
             if plugin:
                 perspective_manager.set_perspective(plugin, hide_and_without_plugin_changes=True)
             elif self._options.perspective_file:
-                perspective_manager.import_perspective_from_file(self._options.perspective_file, perspective_manager.HIDDEN_PREFIX + '__cli_perspective_from_file')
+                perspective_manager.import_perspective_from_file(self._options.perspective_file, perspective_manager.HIDDEN_PREFIX + os.path.basename(self._options.perspective_file))
             else:
                 perspective_manager.set_perspective(self._options.perspective)
 


### PR DESCRIPTION
Instead of having __cli_perspective_from_file for a window title when loading from a perspective file, use the perspective file name.

I couldn't change #83 to kinetic-devel cleanly from the github page, so just made a new PR here.