### PR TITLE
qt_dotgraph: Small fixes for Python3 compatibility

### DIFF
--- a/qt_dotgraph/src/qt_dotgraph/dot_to_qt.py
+++ b/qt_dotgraph/src/qt_dotgraph/dot_to_qt.py
@@ -35,6 +35,8 @@ import pyparsing
 pyparsing._noncomma = "".join([c for c in pyparsing.printables if c != ","])
 import pydot
 
+import codecs
+
 from python_qt_binding.QtCore import QPointF, QRectF
 from python_qt_binding.QtGui import QColor
 
@@ -136,7 +138,6 @@ class DotToQtGenerator():
             print("Error, no label defined for node with attr: %s" % node.attr)
             return None
 
-        import codecs # To work with Python 2 and 3 (https://stackoverflow.com/a/23151714)
         name = codecs.escape_decode(name)[0].decode('utf-8')
 
         # decrease rect by one so that edges do not reach inside
@@ -233,7 +234,7 @@ class DotToQtGenerator():
         # layout graph
         if dotcode is None:
             return {}, {}
-        graph = pydot.graph_from_dot_data(dotcode.decode("ascii", "ignore"))
+        graph = pydot.graph_from_dot_data(dotcode)
         if isinstance(graph, list):
             graph = graph[0]
 

--- a/qt_dotgraph/src/qt_dotgraph/dot_to_qt.py
+++ b/qt_dotgraph/src/qt_dotgraph/dot_to_qt.py
@@ -135,7 +135,9 @@ class DotToQtGenerator():
         if name is None:
             print("Error, no label defined for node with attr: %s" % node.attr)
             return None
-        name = name.decode('string_escape')
+
+        import codecs # To work with Python 2 and 3 (https://stackoverflow.com/a/23151714)
+        name = codecs.escape_decode(name)[0].decode('utf-8')
 
         # decrease rect by one so that edges do not reach inside
         bb_width = node.attr.get('width', len(name) / 5)
@@ -231,7 +233,7 @@ class DotToQtGenerator():
         # layout graph
         if dotcode is None:
             return {}, {}
-        graph = pydot.graph_from_dot_data(dotcode.encode("ascii", "ignore"))
+        graph = pydot.graph_from_dot_data(dotcode.decode("ascii", "ignore"))
         if isinstance(graph, list):
             graph = graph[0]
 

--- a/qt_dotgraph/src/qt_dotgraph/pydotfactory.py
+++ b/qt_dotgraph/src/qt_dotgraph/pydotfactory.py
@@ -166,5 +166,7 @@ class PydotFactory():
 
     def create_dot(self, graph):
         dot = graph.create_dot()
+        if type(dot) != str:
+            dot = dot.decode()
         # sadly pydot generates line wraps cutting between numbers
-        return dot.replace(b"\\\n", b"")
+        return dot.replace("\\\n", "")

--- a/qt_dotgraph/src/qt_dotgraph/pydotfactory.py
+++ b/qt_dotgraph/src/qt_dotgraph/pydotfactory.py
@@ -167,4 +167,4 @@ class PydotFactory():
     def create_dot(self, graph):
         dot = graph.create_dot()
         # sadly pydot generates line wraps cutting between numbers
-        return dot.replace("\\\n", "")
+        return dot.replace(b"\\\n", b"")

--- a/qt_dotgraph/test/dot_to_qt_test.py
+++ b/qt_dotgraph/test/dot_to_qt_test.py
@@ -41,8 +41,8 @@ import subprocess
 
 def check_x_server():
     p = subprocess.Popen(sys.executable, stdin=subprocess.PIPE)
-    p.stdin.write('from python_qt_binding.QtWidgets import QApplication\n')
-    p.stdin.write('app = QApplication([])\n')
+    p.stdin.write(b'from python_qt_binding.QtWidgets import QApplication\n')
+    p.stdin.write(b'app = QApplication([])\n')
     p.stdin.close()
     p.communicate()
 
@@ -53,7 +53,7 @@ def check_x_server():
 
 class DotToQtGeneratorTest(unittest.TestCase):
 
-    DOT_CODE = '''
+    DOT_CODE = r'''
     digraph graph_name {
         graph [bb="0,0,154,108",
             rank=same

--- a/qt_dotgraph/test/pygraphviz_factory_test.py
+++ b/qt_dotgraph/test/pygraphviz_factory_test.py
@@ -57,7 +57,7 @@ class PygraphvizFactoryTest(unittest.TestCase):
         self.assertEqual(1, len(g.nodes()))
         self.assertEqual('graph', g.nodes()[0].get_name())
         self.assertEqual('graph', g.nodes()[0].attr['label'])
-        
+
     def test_add_edge(self):
         fac = PygraphvizFactory()
         g = fac.get_graph()


### PR DESCRIPTION
Mainly to get `rqt_graph` working with Python3. https://github.com/ros-visualization/rqt_graph/pull/10 is also required for `rqt_graph` to work with Python3.