### PR TITLE
Hide the remaining title bar elements not disabled by -l and -f kinetic

### DIFF
--- a/qt_gui/resource/dock_widget_title_bar.ui
+++ b/qt_gui/resource/dock_widget_title_bar.ui
@@ -78,7 +78,7 @@
      <property name="sizeHint" stdset="0">
       <size>
        <width>8</width>
-       <height>10</height>
+       <height>0</height>
       </size>
      </property>
     </spacer>
@@ -230,7 +230,7 @@
      <property name="sizeHint" stdset="0">
       <size>
        <width>8</width>
-       <height>10</height>
+       <height>0</height>
       </size>
      </property>
     </spacer>

--- a/qt_gui/src/qt_gui/dock_widget_title_bar.py
+++ b/qt_gui/src/qt_gui/dock_widget_title_bar.py
@@ -95,9 +95,15 @@ class DockWidgetTitleBar(QWidget):
         self.title_edit.returnPressed.connect(self._update_title_label)
 
         if hide_title:
+            # hide all except the configuration button if present
             self.icon_label.hide()
             self.title_label.hide()
+            self.dockable_button.hide()
+            self.reload_button.hide()
             self.help_button.hide()
+            self.minimize_button.hide()
+            self.float_button.hide()
+            self.close_button.hide()
 
     def __del__(self):
         self._dock_widget.removeEventFilter(self)

--- a/qt_gui/src/qt_gui/dock_widget_title_bar.py
+++ b/qt_gui/src/qt_gui/dock_widget_title_bar.py
@@ -40,7 +40,7 @@ class DockWidgetTitleBar(QWidget):
 
     """Title bar for dock widgets providing custom actions."""
 
-    def __init__(self, dock_widget, qtgui_path):
+    def __init__(self, dock_widget, qtgui_path, hide_title=False):
         super(DockWidgetTitleBar, self).__init__(dock_widget)
         self._dock_widget = dock_widget
 
@@ -93,6 +93,11 @@ class DockWidgetTitleBar(QWidget):
         self.title_edit.hide()
         self.title_edit.editingFinished.connect(self._finished_editing)
         self.title_edit.returnPressed.connect(self._update_title_label)
+
+        if hide_title:
+            self.icon_label.hide()
+            self.title_label.hide()
+            self.help_button.hide()
 
     def __del__(self):
         self._dock_widget.removeEventFilter(self)

--- a/qt_gui/src/qt_gui/main.py
+++ b/qt_gui/src/qt_gui/main.py
@@ -87,6 +87,9 @@ class Main(object):
         if not standalone:
             common_group.add_argument('-l', '--lock-perspective', dest='lock_perspective', action='store_true',
                 help='lock the GUI to the used perspective (hide menu bar and close buttons of plugins)')
+            common_group.add_argument('-ht', '--hide-title', dest='hide_title', action='store_true',
+                help='hide the title label, the icon, and the help button (combine with -l and -f to eliminate the entire title bar and reclaim the space)')
+
             common_group.add_argument('-m', '--multi-process', dest='multi_process', default=False, action='store_true',
                 help='use separate processes for each plugin instance (currently only supported under X11)')
             common_group.add_argument('-p', '--perspective', dest='perspective', type=str, metavar='PERSPECTIVE',
@@ -204,6 +207,7 @@ class Main(object):
         if standalone:
             self._options.freeze_layout = False
             self._options.lock_perspective = False
+            self._options.hide_title = False
             self._options.multi_process = False
             self._options.perspective = None
             self._options.perspective_file = None

--- a/qt_gui/src/qt_gui/plugin_handler.py
+++ b/qt_gui/src/qt_gui/plugin_handler.py
@@ -255,7 +255,7 @@ class PluginHandler(QObject):
         if title_bar is None:
             title_bar = DockWidgetTitleBar(
                 dock_widget, self._application_context.qtgui_path,
-                self._application_context.options.hide_title)
+                hide_title=self._application_context.options.hide_title)
             dock_widget.setTitleBarWidget(title_bar)
 
             # connect extra buttons

--- a/qt_gui/src/qt_gui/plugin_handler.py
+++ b/qt_gui/src/qt_gui/plugin_handler.py
@@ -253,7 +253,9 @@ class PluginHandler(QObject):
     def _update_title_bar(self, dock_widget, hide_help=False, hide_reload=False):
         title_bar = dock_widget.titleBarWidget()
         if title_bar is None:
-            title_bar = DockWidgetTitleBar(dock_widget, self._application_context.qtgui_path)
+            title_bar = DockWidgetTitleBar(
+                dock_widget, self._application_context.qtgui_path,
+                self._application_context.options.hide_title)
             dock_widget.setTitleBarWidget(title_bar)
 
             # connect extra buttons


### PR DESCRIPTION
I'm not sure how to switch #82 over to kinetic-devel cleanly so trying again with a new branch.