### PR TITLE
Fix perspective export with Python3

### DIFF
--- a/qt_gui/src/qt_gui/perspective_manager.py
+++ b/qt_gui/src/qt_gui/perspective_manager.py
@@ -408,11 +408,14 @@ class PerspectiveManager(QObject):
             # add pretty print for better readability
             characters = ''
             for i in range(1, value.size(), 2):
-                character = value.at(i)
-                # output all non-control characters
-                if character >= ' ' and character <= '~':
-                    characters += character
-                else:
+                try:
+                    character = value.at(i)
+                    # output all non-control characters
+                    if character >= ' ' and character <= '~':
+                        characters += character
+                    else:
+                        characters += ' '
+                except UnicodeDecodeError:
                     characters += ' '
             data['pretty-print'] = characters
 


### PR DESCRIPTION
Fixes error of the kind:
`UnicodeDecodeError: 'ascii' codec can't decode byte 0xd9 in position 0: ordinal not in range(128)`
when exporting a perspective