### PR TITLE
[fix][qt_dotgraph] Escaping '/' to '_' is unnecessary.

### DIFF
--- a/qt_dotgraph/src/qt_dotgraph/pydotfactory.py
+++ b/qt_dotgraph/src/qt_dotgraph/pydotfactory.py
@@ -57,7 +57,6 @@ class PydotFactory():
 
     def escape_name(self, name):
         ret = quote(name.strip())
-        ret = ret.replace('/', '_')
         ret = ret.replace('%', '_')
         ret = ret.replace('-', '_')
         return self.escape_label(ret)


### PR DESCRIPTION
AFAI see http://wiki.ros.org/Names, graph names allow `'/'` and there doesn't seem to be a need to convert it to `'_'`.

This resolves issues like https://github.com/ros-visualization/rqt_tf_tree/issues/4.
However I haven't manually tested this with abundant usecases.