### PR TITLE
avoid collision of topic nodes with / and _

### DIFF
--- a/qt_dotgraph/src/qt_dotgraph/pydotfactory.py
+++ b/qt_dotgraph/src/qt_dotgraph/pydotfactory.py
@@ -57,7 +57,7 @@ class PydotFactory():
 
     def escape_name(self, name):
         ret = quote(name.strip())
-        ret = ret.replace('/', '_')
+        ret = ret.replace('/', '__')
         ret = ret.replace('%', '_')
         ret = ret.replace('-', '_')
         return self.escape_label(ret)


### PR DESCRIPTION
Replaces #94.

Fixes ros-visualization/rqt_graph#11.

Since topics may contain underscores as well as slashes the previous replacement make `foo/bar` and `foo_bar` map to the same dot node name.