### PR TITLE
add missing tinyxml include

### DIFF
--- a/qt_gui_cpp/include/qt_gui_cpp/ros_pluginlib_plugin_provider.h
+++ b/qt_gui_cpp/include/qt_gui_cpp/ros_pluginlib_plugin_provider.h
@@ -43,6 +43,7 @@
 //#include <boost/shared_ptr.hpp>
 
 #include <pluginlib/class_loader.h>
+#include <tinyxml.h>
 
 #include <QCoreApplication>
 #include <QEvent>


### PR DESCRIPTION
This package declares a build dependency on tinyxml but relies on `<pluginlib/class_loader.h>` to include it.