### PR TITLE
add missing build_export_depend on TinyXML

### DIFF
--- a/qt_gui_cpp/package.xml
+++ b/qt_gui_cpp/package.xml
@@ -25,6 +25,7 @@
 
   <run_depend version_gte="1.9.23">pluginlib</run_depend>
   <run_depend version_gte="0.3.0">qt_gui</run_depend>
+  <run_depend>tinyxml</run_depend>
 
   <export>
     <qt_gui plugin="${prefix}/plugin.xml"/>


### PR DESCRIPTION
Fix http://build.ros.org/view/Lbin_uX64/job/Lbin_uX64__rqt_gui_cpp__ubuntu_xenial_amd64__binary/20/