### PR TITLE
Hide the menu bar when using lock perspective

### DIFF
--- a/qt_gui/src/qt_gui/main.py
+++ b/qt_gui/src/qt_gui/main.py
@@ -395,12 +395,15 @@ class Main(object):
             timer.start(500)
             timer.timeout.connect(lambda: None)
 
-            menu_bar = main_window.menuBar()
-            file_menu = menu_bar.addMenu(menu_bar.tr('&File'))
-            action = QAction(file_menu.tr('&Quit'), file_menu)
-            action.setIcon(QIcon.fromTheme('application-exit'))
-            action.triggered.connect(main_window.close)
-            file_menu.addAction(action)
+            if not self._options.lock_perspective:
+                menu_bar = main_window.menuBar()
+                file_menu = menu_bar.addMenu(menu_bar.tr('&File'))
+                action = QAction(file_menu.tr('&Quit'), file_menu)
+                action.setIcon(QIcon.fromTheme('application-exit'))
+                action.triggered.connect(main_window.close)
+                file_menu.addAction(action)
+            else:
+                menu_bar = None
 
         else:
             app.setQuitOnLastWindowClosed(False)

--- a/qt_gui/src/qt_gui/main.py
+++ b/qt_gui/src/qt_gui/main.py
@@ -477,7 +477,7 @@ class Main(object):
         if main_window is not None and menu_bar is not None:
             about_handler = AboutHandler(context.qtgui_path, main_window)
             help_menu = menu_bar.addMenu(menu_bar.tr('&Help'))
-            action = QAction(file_menu.tr('&About'), help_menu)
+            action = QAction(help_menu.tr('&About'), help_menu)
             action.setIcon(QIcon.fromTheme('help-about'))
             action.triggered.connect(about_handler.show)
             help_menu.addAction(action)

--- a/qt_gui/src/qt_gui/main.py
+++ b/qt_gui/src/qt_gui/main.py
@@ -438,14 +438,14 @@ class Main(object):
 
         if main_window is not None:
             container_manager = ContainerManager(main_window, plugin_manager)
-            plugin_manager.set_main_window(main_window, menu_bar if not self._options.lock_perspective else None, container_manager)
+            plugin_manager.set_main_window(main_window, menu_bar, container_manager)
 
             if not self._options.freeze_layout:
                 minimized_dock_widgets_toolbar = MinimizedDockWidgetsToolbar(container_manager, main_window)
                 main_window.addToolBar(Qt.BottomToolBarArea, minimized_dock_widgets_toolbar)
                 plugin_manager.set_minimized_dock_widgets_toolbar(minimized_dock_widgets_toolbar)
 
-        if menu_bar is not None and not self._options.lock_perspective:
+        if menu_bar is not None:
             perspective_menu = menu_bar.addMenu(menu_bar.tr('P&erspectives'))
             perspective_manager.set_menu(perspective_menu)
 


### PR DESCRIPTION
This used to already be true a few months ago but regressed (or was it in another branch that it worked?)  #21

Currently File and Help are still visible though the other menu bar items are removed by the -lock-perspective option, this pr prevent the menu_bar from getting created at all.