### PR TITLE
Avoid crash when a plugin in .perspective is not available 

### DIFF
--- a/qt_gui/src/qt_gui/plugin_manager.py
+++ b/qt_gui/src/qt_gui/plugin_manager.py
@@ -222,6 +222,9 @@ class PluginManager(QObject):
 
         handler.set_minimized_dock_widgets_toolbar(self._minimized_dock_widgets_toolbar)
 
+        if instance_id.plugin_id not in self._plugin_descriptors.keys():
+            qWarning('plugin "%s" not available' % (instance_id.plugin_id))
+            return
         plugin_descriptor = self._plugin_descriptors[instance_id.plugin_id]
         handler.set_plugin_descriptor(plugin_descriptor)
 

--- a/qt_gui/src/qt_gui/plugin_manager.py
+++ b/qt_gui/src/qt_gui/plugin_manager.py
@@ -223,7 +223,9 @@ class PluginManager(QObject):
         handler.set_minimized_dock_widgets_toolbar(self._minimized_dock_widgets_toolbar)
 
         if instance_id.plugin_id not in self._plugin_descriptors.keys():
-            qWarning('plugin "%s" not available' % (instance_id.plugin_id))
+            qWarning(
+                'PluginManager._load_plugin() could not load plugin "%s": plugin not available' %
+                (instance_id.plugin_id))
             return
         plugin_descriptor = self._plugin_descriptors[instance_id.plugin_id]
         handler.set_plugin_descriptor(plugin_descriptor)


### PR DESCRIPTION
Print a warning instead.

The perspective loads and there is no way to know by only looking at the rqt window that anything is missing, just the qWarning message.

Saving a perspective after doing this is somewhat wonky - the perspective still has the unloaded plugin in it but it isn't visible, so even after loading the perspective when the plugin is available it doesn't become visible.

#109