### PR TITLE
Load and save perspective file path and name adjustments

### DIFF
--- a/qt_gui/src/qt_gui/perspective_manager.py
+++ b/qt_gui/src/qt_gui/perspective_manager.py
@@ -311,8 +311,9 @@ class PerspectiveManager(QObject):
             self._remove_action.setEnabled(False)
 
     def _on_import_perspective(self):
-        file_name, _ = QFileDialog.getOpenFileName(self._menu_manager.menu, self.tr('Import perspective from file'),
-                                                   self._file_path, self.tr('Perspectives (*.perspective)'))
+        file_name, _ = QFileDialog.getOpenFileName(
+            self._menu_manager.menu, self.tr('Import perspective from file'),
+            self._file_path, self.tr('Perspectives (*.perspective)'))
         if file_name is None or file_name == '':
             return
 
@@ -360,8 +361,9 @@ class PerspectiveManager(QObject):
         suffix = '.perspective'
         if not save_file_name.endswith(suffix):
             save_file_name += '.perspective'
-        file_name, _ = QFileDialog.getSaveFileName(self._menu_manager.menu, self.tr('Export perspective to file'),
-                                                   save_file_name, self.tr('Perspectives (*.perspective)'))
+        file_name, _ = QFileDialog.getSaveFileName(
+            self._menu_manager.menu, self.tr('Export perspective to file'),
+            save_file_name, self.tr('Perspectives (*.perspective)'))
         if file_name is None or file_name == '':
             return
         self._file_path = os.path.dirname(file_name)

--- a/qt_gui/src/qt_gui/perspective_manager.py
+++ b/qt_gui/src/qt_gui/perspective_manager.py
@@ -85,6 +85,8 @@ class PerspectiveManager(QObject):
         self._callback = None
         self._callback_args = []
 
+        self._file_path = ''
+
         if application_context.provide_app_dbus_interfaces:
             from .perspective_manager_dbus_interface import PerspectiveManagerDBusInterface
             self._dbus_server = PerspectiveManagerDBusInterface(self, application_context)
@@ -309,7 +311,8 @@ class PerspectiveManager(QObject):
             self._remove_action.setEnabled(False)
 
     def _on_import_perspective(self):
-        file_name, _ = QFileDialog.getOpenFileName(self._menu_manager.menu, self.tr('Import perspective from file'), None, self.tr('Perspectives (*.perspective)'))
+        file_name, _ = QFileDialog.getOpenFileName(self._menu_manager.menu, self.tr('Import perspective from file'),
+                                                   self._file_path, self.tr('Perspectives (*.perspective)'))
         if file_name is None or file_name == '':
             return
 
@@ -325,6 +328,7 @@ class PerspectiveManager(QObject):
         self.import_perspective_from_file(file_name, perspective_name)
 
     def import_perspective_from_file(self, path, perspective_name):
+        self._file_path = os.path.dirname(path)
         # create clean perspective
         if perspective_name in self.perspectives:
             self._remove_perspective(perspective_name)
@@ -352,9 +356,15 @@ class PerspectiveManager(QObject):
             self._set_dict_on_settings(groups[group], sub)
 
     def _on_export_perspective(self):
-        file_name, _ = QFileDialog.getSaveFileName(self._menu_manager.menu, self.tr('Export perspective to file'), self._current_perspective + '.perspective', self.tr('Perspectives (*.perspective)'))
+        save_file_name = os.path.join(self._file_path, self._current_perspective.lstrip(self.HIDDEN_PREFIX))
+        suffix = '.perspective'
+        if not save_file_name.endswith(suffix):
+            save_file_name += '.perspective'
+        file_name, _ = QFileDialog.getSaveFileName(self._menu_manager.menu, self.tr('Export perspective to file'),
+                                                   save_file_name, self.tr('Perspectives (*.perspective)'))
         if file_name is None or file_name == '':
             return
+        self._file_path = os.path.dirname(file_name)
 
         # trigger save of perspective before export
         self._callback = self._on_export_perspective_continued

--- a/qt_gui/src/qt_gui/perspective_manager.py
+++ b/qt_gui/src/qt_gui/perspective_manager.py
@@ -360,7 +360,7 @@ class PerspectiveManager(QObject):
         save_file_name = os.path.join(self._file_path, self._current_perspective.lstrip(self.HIDDEN_PREFIX))
         suffix = '.perspective'
         if not save_file_name.endswith(suffix):
-            save_file_name += '.perspective'
+            save_file_name += suffix
         file_name, _ = QFileDialog.getSaveFileName(
             self._menu_manager.menu, self.tr('Export perspective to file'),
             save_file_name, self.tr('Perspectives (*.perspective)'))

--- a/qt_gui/src/qt_gui/perspective_manager.py
+++ b/qt_gui/src/qt_gui/perspective_manager.py
@@ -85,7 +85,7 @@ class PerspectiveManager(QObject):
         self._callback = None
         self._callback_args = []
 
-        self._file_path = ''
+        self._file_path = None
 
         if application_context.provide_app_dbus_interfaces:
             from .perspective_manager_dbus_interface import PerspectiveManagerDBusInterface


### PR DESCRIPTION
When using perspective-file use the directory of that file for later imports or exports in the same session instead of the directory rqt was launched from or ROS_HOME.

Imports or exports will change the directory used as a starting point for later imports and exports if they successfully select a file in a different directory (cancel results in no change).

Strip off HIDDEN_PREFIX and don't redundantly add .perspective suffix- importing test.perspective previously resulted in @tmp.perspective.perspective as the file name to export to.  (HIDDEN_PREFIX looks like something that ought to be handled differently in a future change)

