### PR TITLE
add hint to run with --force-discover, when no plugin found

### DIFF
--- a/qt_gui/src/qt_gui/main.py
+++ b/qt_gui/src/qt_gui/main.py
@@ -503,6 +503,7 @@ class Main(object):
             plugins = plugin_manager.find_plugins_by_name(plugin)
             if len(plugins) == 0:
                 print('qt_gui_main() found no plugin matching "%s"' % plugin)
+                print('please re-run with "--force-discover" option')
                 return 1
             elif len(plugins) > 1:
                 print('qt_gui_main() found multiple plugins matching "%s"\n%s' % (plugin, '\n'.join(plugins.values())))

--- a/qt_gui/src/qt_gui/main.py
+++ b/qt_gui/src/qt_gui/main.py
@@ -503,7 +503,7 @@ class Main(object):
             plugins = plugin_manager.find_plugins_by_name(plugin)
             if len(plugins) == 0:
                 print('qt_gui_main() found no plugin matching "%s"' % plugin)
-                print('please re-run with "--force-discover" option')
+                print('try passing the option "--force-discover"')
                 return 1
             elif len(plugins) > 1:
                 print('qt_gui_main() found multiple plugins matching "%s"\n%s' % (plugin, '\n'.join(plugins.values())))


### PR DESCRIPTION
I had
```
qt_gui_main() found no plugin matching "..."
```
error few times last month, specially just after apt-get installed new rqt plugins. And have to google to find solution. i.e. running rqt with '--force-discover'

https://github.com/ros-visualization/rqt/issues/90 seems relevant, but it only update cache when ROS_PACKAGE_PATH was changed, and apt-get install does not change ROS_PACKAGE_PATH.

The only way I found is to notify users to run '--force-discover'