### PR TITLE
Switch filesystem depends

### DIFF
--- a/qt_gui_cpp/CMakeLists.txt
+++ b/qt_gui_cpp/CMakeLists.txt
@@ -2,14 +2,13 @@ cmake_minimum_required(VERSION 3.5)
 project(qt_gui_cpp)
 
 find_package(ament_cmake REQUIRED)
-find_package(Boost REQUIRED COMPONENTS filesystem system)
 find_package(tinyxml_vendor REQUIRED)
 find_package(pluginlib REQUIRED)
 
 ament_python_install_package(${PROJECT_NAME}
   PACKAGE_DIR src/${PROJECT_NAME})
 
-include_directories(include ${ament_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS} ${TinyXML_INCLUDE_DIRS} ${pluginlib_INCLUDE_DIRS})
+include_directories(include ${ament_INCLUDE_DIRS} ${TinyXML_INCLUDE_DIRS} ${pluginlib_INCLUDE_DIRS})
 
 add_subdirectory(src)
 
@@ -22,7 +21,6 @@ install(
     DESTINATION include
   )
 
-ament_export_dependencies(Boost)
 ament_export_dependencies(TinyXML)
 ament_export_dependencies(pluginlib)
 

--- a/qt_gui_cpp/include/qt_gui_cpp/ros_pluginlib_plugin_provider.h
+++ b/qt_gui_cpp/include/qt_gui_cpp/ros_pluginlib_plugin_provider.h
@@ -38,13 +38,8 @@
 #include "plugin_descriptor.h"
 #include "plugin_provider.h"
 
-// while this header uses boost shared pointers
-// Shiboken2 isn't able to parse it correctly atm
-//#include <boost/shared_ptr.hpp>
-
 #include <pluginlib/class_loader.hpp>
 #include <pluginlib/impl/filesystem_helper.hpp>
-#include <boost/filesystem.hpp>
 #include <tinyxml.h>
 
 #include <QCoreApplication>

--- a/qt_gui_cpp/include/qt_gui_cpp/ros_pluginlib_plugin_provider.h
+++ b/qt_gui_cpp/include/qt_gui_cpp/ros_pluginlib_plugin_provider.h
@@ -43,6 +43,7 @@
 //#include <boost/shared_ptr.hpp>
 
 #include <pluginlib/class_loader.hpp>
+#include <pluginlib/impl/filesystem_helper.hpp>
 #include <boost/filesystem.hpp>
 #include <tinyxml.h>
 
@@ -144,12 +145,8 @@ public:
 
       std::string name = class_loader_->getName(lookup_name);
       std::string plugin_xml = class_loader_->getPluginManifestPath(lookup_name);
-      boost::filesystem::path p(plugin_xml);
-#if BOOST_FILESYSTEM_VERSION >= 3
+      pluginlib::impl::fs::path p(plugin_xml);
       std::string plugin_path = p.parent_path().string();
-#else
-      std::string plugin_path = p.parent_path();
-#endif
 
       QMap<QString, QString> attributes;
       attributes["class_name"] = name.c_str();

--- a/qt_gui_cpp/src/qt_gui_cpp/CMakeLists.txt
+++ b/qt_gui_cpp/src/qt_gui_cpp/CMakeLists.txt
@@ -37,7 +37,7 @@ ament_export_dependencies(pluginlib)
 include_directories(${PROJECT_NAME} ${qt_gui_cpp_INCLUDE_DIRECTORIES} ${pluginlib_INCLUDE_DIRS})
 add_library(${PROJECT_NAME} ${qt_gui_cpp_SRCS} ${qt_gui_cpp_MOCS})
 
-target_link_libraries(${PROJECT_NAME} ${qt_gui_cpp_LINK_LIBRARIES} ${ament_LIBRARIES} ${Boost_LIBRARIES} Qt5::Widgets ${TinyXML_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${qt_gui_cpp_LINK_LIBRARIES} ${ament_LIBRARIES} Qt5::Widgets ${TinyXML_LIBRARIES})
 
 install(TARGETS ${PROJECT_NAME}
   ARCHIVE DESTINATION lib

--- a/qt_gui_cpp/src/qt_gui_cpp_shiboken/CMakeLists.txt
+++ b/qt_gui_cpp/src/qt_gui_cpp_shiboken/CMakeLists.txt
@@ -58,7 +58,7 @@ if(shiboken_helper_FOUND)
       ARCHIVE_OUTPUT_DIRECTORY lib}
       LIBRARY_OUTPUT_DIRECTORY lib}
     )
-    target_link_libraries(qt_gui_cpp_shiboken ${PROJECT_NAME} ${ament_LIBRARIES} ${Boost_LIBRARIES})
+    target_link_libraries(qt_gui_cpp_shiboken ${PROJECT_NAME} ${ament_LIBRARIES})
     shiboken_target_link_libraries(qt_gui_cpp_shiboken "${qt_gui_cpp_shiboken_QT_COMPONENTS}")
 
     install(TARGETS qt_gui_cpp_shiboken

--- a/qt_gui_cpp/src/qt_gui_cpp_sip/CMakeLists.txt
+++ b/qt_gui_cpp/src/qt_gui_cpp_sip/CMakeLists.txt
@@ -28,7 +28,7 @@ set(qt_gui_cpp_sip_DEPENDENT_FILES
 
 # maintain context for different named target
 set(qt_gui_cpp_sip_INCLUDE_DIRS ${qt_gui_cpp_INCLUDE_DIRS} "${CMAKE_CURRENT_SOURCE_DIR}/../../include" ${ament_INCLUDE_DIRS})
-set(qt_gui_cpp_sip_LIBRARIES ${qt_gui_cpp_LIBRARIES} ${Boost_LIBRARIES})
+set(qt_gui_cpp_sip_LIBRARIES ${qt_gui_cpp_LIBRARIES})
 set(qt_gui_cpp_sip_LIBRARY_DIRS ${qt_gui_cpp_LIBRARY_DIRS} lib)
 set(qt_gui_cpp_sip_LDFLAGS_OTHER ${qt_gui_cpp_LDFLAGS_OTHER} -Wl,-rpath,\\"lib\\")
 


### PR DESCRIPTION
This drops the boost::filesystem dependency from qt_gui_cpp in favor of pluginlib/filesystem_helper.hpp.