### PR TITLE
Remove boost depends

### DIFF
--- a/qt_gui_cpp/CMakeLists.txt
+++ b/qt_gui_cpp/CMakeLists.txt
@@ -2,7 +2,6 @@ cmake_minimum_required(VERSION 2.8.3)
 project(qt_gui_cpp)
 
 find_package(catkin REQUIRED COMPONENTS cmake_modules pluginlib)
-find_package(Boost REQUIRED COMPONENTS filesystem system)
 find_package(TinyXML REQUIRED)
 
 catkin_package(
@@ -10,12 +9,12 @@ catkin_package(
   LIBRARIES ${PROJECT_NAME}
   CATKIN_DEPENDS pluginlib
   CFG_EXTRAS ${PROJECT_NAME}-extras.cmake
-  DEPENDS Boost TinyXML
+  DEPENDS TinyXML
 )
 
 catkin_python_setup()
 
-include_directories(include ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS} ${TinyXML_INCLUDE_DIRS})
+include_directories(include ${catkin_INCLUDE_DIRS} ${TinyXML_INCLUDE_DIRS})
 
 add_subdirectory(src)
 

--- a/qt_gui_cpp/src/qt_gui_cpp/CMakeLists.txt
+++ b/qt_gui_cpp/src/qt_gui_cpp/CMakeLists.txt
@@ -36,7 +36,7 @@ qt5_wrap_cpp(qt_gui_cpp_MOCS ${qt_gui_cpp_HDRS})
 
 include_directories(${PROJECT_NAME} ${qt_gui_cpp_INCLUDE_DIRECTORIES})
 add_library(${PROJECT_NAME} ${qt_gui_cpp_SRCS} ${qt_gui_cpp_MOCS})
-target_link_libraries(${PROJECT_NAME} ${qt_gui_cpp_LINK_LIBRARIES} ${catkin_LIBRARIES} ${Boost_LIBRARIES} Qt5::Widgets ${TinyXML_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${qt_gui_cpp_LINK_LIBRARIES} ${catkin_LIBRARIES} Qt5::Widgets ${TinyXML_LIBRARIES})
 
 install(TARGETS ${PROJECT_NAME}
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}

--- a/qt_gui_cpp/src/qt_gui_cpp_shiboken/CMakeLists.txt
+++ b/qt_gui_cpp/src/qt_gui_cpp_shiboken/CMakeLists.txt
@@ -58,7 +58,7 @@ if(shiboken_helper_FOUND)
       ARCHIVE_OUTPUT_DIRECTORY ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_PYTHON_DESTINATION}
       LIBRARY_OUTPUT_DIRECTORY ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_PYTHON_DESTINATION}
     )
-    target_link_libraries(qt_gui_cpp_shiboken ${PROJECT_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+    target_link_libraries(qt_gui_cpp_shiboken ${PROJECT_NAME} ${catkin_LIBRARIES})
     shiboken_target_link_libraries(qt_gui_cpp_shiboken "${qt_gui_cpp_shiboken_QT_COMPONENTS}")
 
     install(TARGETS qt_gui_cpp_shiboken

--- a/qt_gui_cpp/src/qt_gui_cpp_sip/CMakeLists.txt
+++ b/qt_gui_cpp/src/qt_gui_cpp_sip/CMakeLists.txt
@@ -28,7 +28,7 @@ set(qt_gui_cpp_sip_DEPENDENT_FILES
 
 # maintain context for different named target
 set(qt_gui_cpp_sip_INCLUDE_DIRS ${qt_gui_cpp_INCLUDE_DIRS} "${CMAKE_CURRENT_SOURCE_DIR}/../../include" ${catkin_INCLUDE_DIRS})
-set(qt_gui_cpp_sip_LIBRARIES ${qt_gui_cpp_LIBRARIES} ${PROJECT_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+set(qt_gui_cpp_sip_LIBRARIES ${qt_gui_cpp_LIBRARIES} ${PROJECT_NAME} ${catkin_LIBRARIES})
 set(qt_gui_cpp_sip_LIBRARY_DIRS ${qt_gui_cpp_LIBRARY_DIRS} ${CATKIN_DEVEL_PREFIX}/lib)
 set(qt_gui_cpp_sip_LDFLAGS_OTHER ${qt_gui_cpp_LDFLAGS_OTHER} -Wl,-rpath,\\"${CATKIN_DEVEL_PREFIX}/lib\\")
 


### PR DESCRIPTION
This removes all boost dependencies from qt_gui_core. There were two instances, boost::shared_ptrs which have been replaced with std::share_ptrs and boost::filesystem which has been replaced by pluginlib/filesystem_helper.

Note: This won't build correctly on ros2 systems and requires other pull requests for a complete build. Currently #132 and #133