### PR TITLE
Ros2 port w tests

### DIFF
--- a/qt_dotgraph/CMakeLists.txt
+++ b/qt_dotgraph/CMakeLists.txt
@@ -2,12 +2,19 @@ cmake_minimum_required(VERSION 3.5)
 project(qt_dotgraph)
 
 find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_python REQUIRED)
 
 ament_python_install_package(${PROJECT_NAME}
   PACKAGE_DIR src/${PROJECT_NAME})
 
-if (CATKIN_ENABLE_TESTING)
-  catkin_add_nosetests(test)
+if(BUILD_TESTING)
+  find_package(ament_cmake_pytest REQUIRED)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+
+  ament_add_pytest_test(${PROJECT_NAME} test
+    APPEND_ENV PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}
+    TIMEOUT 90)
 endif()
 
 ament_package()

--- a/qt_dotgraph/package.xml
+++ b/qt_dotgraph/package.xml
@@ -18,5 +18,11 @@
   <exec_depend>python3-pydot</exec_depend>
   <exec_depend version_gte="0.3.0">python_qt_binding</exec_depend>
 
+  <test_depend>ament_cmake_pytest</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_flake8</test_depend>
+  <test_depend>ament_pep257</test_depend>
+  <test_depend>python3-pytest</test_depend>
+
   <test_depend>python3-pygraphviz</test_depend>
 </package>

--- a/qt_dotgraph/test/dot_to_qt_test.py
+++ b/qt_dotgraph/test/dot_to_qt_test.py
@@ -125,7 +125,7 @@ class DotToQtGeneratorTest(unittest.TestCase):
 
         gen = DotToQtGenerator()
         dotcode = r'''
-        strict digraph {
+        strict digraph "" {
             graph [bb="0,0,249,541",
                     compound=True,
                     rank=same,
@@ -224,15 +224,21 @@ class DotToQtGeneratorTest(unittest.TestCase):
         (nodes, edges) = gen.dotcode_to_qt_items(dotcode, 1)
 
         expected_nodes = [
-            '"/Container/Subcontainer"', '"/Container/finished"', '"/start"', '"/Container"',
-            '"/Container/Subcontainer/logstate1"', '"/Container/Subcontainer/finished"',
-            '"/Container/logstate"', '"/finished"']
+            '"/Container"', '"/Container/Subcontainer"', '"/Container/Subcontainer/finished"',
+            '"/Container/Subcontainer/logstate1"', '"/Container/finished"', '"/Container/logstate"',
+            '"/finished"', '"/start"'
+            ]
         expected_edges = [
-            '/Container/logstate_TO_/Container/finished_done',
             '/Container/Subcontainer/finished_TO_/Container/finished_finished',
-            '/start_TO_/Container/Subcontainer/logstate1',
+            '/Container/Subcontainer/logstate1_TO_/Container/Subcontainer/finished_done',
             '/Container/finished_TO_/finished_finished',
+            '/Container/logstate_TO_/Container/finished_done',
+            '/start_TO_/Container/Subcontainer/logstate1',
             '/start_TO_/Container/logstate',
-            '/Container/Subcontainer/logstate1_TO_/Container/Subcontainer/finished_done']
-        self.assertEqual(expected_nodes, nodes.keys())
-        self.assertEqual(expected_edges, edges.keys())
+            ]
+
+        nodes_sorted = list(sorted(nodes.keys()))
+        edges_sorted = list(sorted(edges.keys()))
+
+        self.assertEqual(expected_nodes, nodes_sorted)
+        self.assertEqual(expected_edges, edges_sorted)

--- a/qt_dotgraph/test/pydot_factory_test.py
+++ b/qt_dotgraph/test/pydot_factory_test.py
@@ -32,6 +32,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 import unittest
+
 from qt_dotgraph.pydotfactory import PydotFactory
 
 
@@ -40,8 +41,8 @@ class PyDotFactoryTest(unittest.TestCase):
     def test_get_graph(self):
         fac = PydotFactory()
         g = fac.get_graph()
-        self.assertEquals('same', g.get_rank())
-        self.assertEquals('digraph', g.get_graph_type())
+        self.assertEqual('same', g.get_rank())
+        self.assertEqual('digraph', g.get_graph_type())
 
     def test_add_node(self):
         fac = PydotFactory()

--- a/qt_dotgraph/test/pygraphviz_factory_test.py
+++ b/qt_dotgraph/test/pygraphviz_factory_test.py
@@ -32,6 +32,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 import unittest
+
 from qt_dotgraph.pygraphvizfactory import PygraphvizFactory
 
 
@@ -40,7 +41,7 @@ class PygraphvizFactoryTest(unittest.TestCase):
     def test_get_graph(self):
         fac = PygraphvizFactory()
         g = fac.get_graph()
-        self.assertEquals('same', g.graph_attr['rank'])
+        self.assertEqual('same', g.graph_attr['rank'])
         self.assertTrue(g.is_directed())
 
     def test_add_node(self):
@@ -93,7 +94,7 @@ class PygraphvizFactoryTest(unittest.TestCase):
         fac.add_node_to_graph(g, 'edge')
         fac.add_edge_to_graph(g, 'foo', 'edge')
         fac.add_subgraph_to_graph(g, 'graph')
-        snippets = ['strict digraph {\n\tgraph',
+        snippets = ['strict digraph "" {\n\tgraph',
                     'foo',
                     'label=foo',
                     '"edge"',

--- a/qt_dotgraph/test/test_flake8.py
+++ b/qt_dotgraph/test/test_flake8.py
@@ -1,0 +1,23 @@
+# Copyright 2017 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ament_flake8.main import main
+import pytest
+
+
+@pytest.mark.flake8
+@pytest.mark.linter
+def test_flake8():
+    rc = main(argv=['--exclude', 'dot_to_qt_test.py'])
+    assert rc == 0, 'Found errors'

--- a/qt_dotgraph/test/test_pep257.py
+++ b/qt_dotgraph/test/test_pep257.py
@@ -1,0 +1,23 @@
+# Copyright 2015 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ament_pep257.main import main
+import pytest
+
+
+@pytest.mark.linter
+@pytest.mark.pep257
+def test_pep257():
+    rc = main(argv=['.', 'test'])
+    assert rc == 0, 'Found code style errors / warnings'

--- a/qt_gui/CMakeLists.txt
+++ b/qt_gui/CMakeLists.txt
@@ -8,6 +8,16 @@ ament_python_install_package(${PROJECT_NAME}
   PACKAGE_DIR src/${PROJECT_NAME})
 
 install(DIRECTORY resource
-  DESTINATION share)
+  DESTINATION share/${PROJECT_NAME})
+
+if(BUILD_TESTING)
+  find_package(ament_cmake_pytest REQUIRED)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+
+  ament_add_pytest_test(${PROJECT_NAME} test
+    APPEND_ENV PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}
+    TIMEOUT 90)
+endif()
 
 ament_package()

--- a/qt_gui/package.xml
+++ b/qt_gui/package.xml
@@ -25,6 +25,12 @@
   <exec_depend>python3-catkin-pkg-modules</exec_depend>
   <exec_depend>tango-icon-theme</exec_depend>
 
+  <test_depend>ament_cmake_pytest</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_flake8</test_depend>
+  <test_depend>ament_pep257</test_depend>
+  <test_depend>python3-pytest</test_depend>
+  
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/qt_gui/src/qt_gui/about_handler.py
+++ b/qt_gui/src/qt_gui/about_handler.py
@@ -53,7 +53,7 @@ class AboutHandler(QObject):
     def show(self):
         try:
             # append folder of 'qt_gui_cpp/lib' to module search path
-            qt_gui_cpp_path = os.path.realpath(get_package_path('qt_gui_cpp'))
+            qt_gui_cpp_path = os.path.realpath(get_package_path('qt_gui'))
         except Exception:
             qt_gui_cpp = None
         else:
@@ -61,10 +61,8 @@ class AboutHandler(QObject):
             sys.path.append(os.path.join(qt_gui_cpp_path, 'src'))
             from qt_gui_cpp.cpp_binding_helper import qt_gui_cpp
 
-        import rospkg
-        _rospkg_version = getattr(rospkg, '__version__', '&lt; 0.2.4')
-
-        logo = os.path.join(self._qtgui_path, 'resource', 'ros_org_vertical.png')
+        logo = os.path.join(
+            self._qtgui_path, 'share', 'qt_gui', 'resource', 'ros_org_vertical.png')
         text = '<img src="%s" width="56" height="200" style="float: left;"/>' % logo
 
         text += '<h3 style="margin-top: 1px;">%s</h3>' % self.tr('rqt')
@@ -80,8 +78,6 @@ class AboutHandler(QObject):
         text += '<p>%s: ' % self.tr('Utilized libraries:')
 
         text += 'Python %s, ' % platform.python_version()
-
-        text += 'rospkg %s, ' % _rospkg_version
 
         if QT_BINDING == 'pyside':
             text += 'PySide'

--- a/qt_gui/src/qt_gui/dock_widget_title_bar.py
+++ b/qt_gui/src/qt_gui/dock_widget_title_bar.py
@@ -43,7 +43,8 @@ class DockWidgetTitleBar(QWidget):
         super(DockWidgetTitleBar, self).__init__(dock_widget)
         self._dock_widget = dock_widget
 
-        ui_file = os.path.join(qtgui_path, 'resource', 'dock_widget_title_bar.ui')
+        ui_file = os.path.join(
+            qtgui_path, 'share', 'qt_gui', 'resource', 'dock_widget_title_bar.ui')
         loadUi(ui_file, self)
         self._extra_buttons = {
             'configuration': self.configuration_button,

--- a/qt_gui/src/qt_gui/main.py
+++ b/qt_gui/src/qt_gui/main.py
@@ -33,12 +33,12 @@
 from __future__ import print_function
 
 from argparse import ArgumentParser, SUPPRESS
-from ament_index_python.resources import get_resource
-
 import os
 import platform
 import signal
 import sys
+
+from ament_index_python.resources import get_resource
 
 
 class Main(object):

--- a/qt_gui/src/qt_gui/plugin_handler_direct.py
+++ b/qt_gui/src/qt_gui/plugin_handler_direct.py
@@ -121,8 +121,8 @@ class PluginHandlerDirect(PluginHandler):
                 self._plugin.restore_settings(plugin_settings_plugin, instance_settings_plugin)
             except Exception:
                 qCritical(
-                    'PluginHandlerDirect._restore_settings() plugin "%s" raised an exception:\n%s' %
-                    (str(self._instance_id), traceback.format_exc()))
+                    'PluginHandlerDirect._restore_settings() plugin "%s" raised an '
+                    'exception:\n%s' % (str(self._instance_id), traceback.format_exc()))
         self.emit_restore_settings_completed()
 
     # pointer to QWidget must be used for PySide to work (at least with 1.0.1)

--- a/qt_gui/src/qt_gui/ros_package_helper.py
+++ b/qt_gui/src/qt_gui/ros_package_helper.py
@@ -30,7 +30,7 @@
 
 
 def get_package_path(name):
-    """Helper function to determine the path of a ROS package using rospkg."""
+    """Determine the path of a ROS package using rospkg."""
     from ament_index_python.resources import get_resource
     _, package_path = get_resource('packages', name)
     return package_path

--- a/qt_gui/test/test_flake8.py
+++ b/qt_gui/test/test_flake8.py
@@ -1,0 +1,23 @@
+# Copyright 2017 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ament_flake8.main import main
+import pytest
+
+
+@pytest.mark.flake8
+@pytest.mark.linter
+def test_flake8():
+    rc = main(argv=[])
+    assert rc == 0, 'Found errors'

--- a/qt_gui/test/test_pep257.py
+++ b/qt_gui/test/test_pep257.py
@@ -1,0 +1,23 @@
+# Copyright 2015 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ament_pep257.main import main
+import pytest
+
+
+@pytest.mark.linter
+@pytest.mark.pep257
+def test_pep257():
+    rc = main(argv=['.', 'test'])
+    assert rc == 0, 'Found code style errors / warnings'

--- a/qt_gui_app/CMakeLists.txt
+++ b/qt_gui_app/CMakeLists.txt
@@ -6,4 +6,14 @@ find_package(ament_cmake_python REQUIRED)
 
 install(PROGRAMS scripts/qt_gui_app DESTINATION bin)
 
+if(BUILD_TESTING)
+  find_package(ament_cmake_pytest REQUIRED)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+
+  ament_add_pytest_test(${PROJECT_NAME} test
+    APPEND_ENV PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}
+    TIMEOUT 90)
+endif()
+
 ament_package()

--- a/qt_gui_app/package.xml
+++ b/qt_gui_app/package.xml
@@ -17,6 +17,13 @@
 
   <exec_depend>ament_index_python</exec_depend>
   <exec_depend>qt_gui</exec_depend>
+
+  <test_depend>ament_cmake_pytest</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_flake8</test_depend>
+  <test_depend>ament_pep257</test_depend>
+  <test_depend>python3-pytest</test_depend>
+  
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/qt_gui_app/scripts/qt_gui_app
+++ b/qt_gui_app/scripts/qt_gui_app
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import sys

--- a/qt_gui_app/test/test_flake8.py
+++ b/qt_gui_app/test/test_flake8.py
@@ -1,0 +1,23 @@
+# Copyright 2017 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ament_flake8.main import main
+import pytest
+
+
+@pytest.mark.flake8
+@pytest.mark.linter
+def test_flake8():
+    rc = main(argv=[])
+    assert rc == 0, 'Found errors'

--- a/qt_gui_app/test/test_pep257.py
+++ b/qt_gui_app/test/test_pep257.py
@@ -1,0 +1,23 @@
+# Copyright 2015 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ament_pep257.main import main
+import pytest
+
+
+@pytest.mark.linter
+@pytest.mark.pep257
+def test_pep257():
+    rc = main(argv=['.', 'test'])
+    assert rc == 0, 'Found code style errors / warnings'

--- a/qt_gui_cpp/CMakeLists.txt
+++ b/qt_gui_cpp/CMakeLists.txt
@@ -25,4 +25,14 @@ ament_export_dependencies(TinyXML)
 ament_export_include_directories(include)
 ament_export_libraries(${PROJECT_NAME})
 
+if(BUILD_TESTING)
+  find_package(ament_cmake_pytest REQUIRED)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+
+  ament_add_pytest_test(${PROJECT_NAME} test
+    APPEND_ENV PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}
+    TIMEOUT 90)
+endif()
+
 ament_package(CONFIG_EXTRAS cmake/${PROJECT_NAME}-extras.cmake)

--- a/qt_gui_cpp/package.xml
+++ b/qt_gui_cpp/package.xml
@@ -29,6 +29,13 @@
   <exec_depend>tinyxml_vendor</exec_depend>
   <exec_depend>tinyxml</exec_depend>
 
+  <test_depend>ament_cmake_pytest</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_flake8</test_depend>
+  <test_depend>ament_pep257</test_depend>
+  <test_depend>python3-pytest</test_depend>
+  
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/qt_gui_cpp/setup.py
+++ b/qt_gui_cpp/setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from distutils.core import setup
+
 from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup(

--- a/qt_gui_cpp/test/test_flake8.py
+++ b/qt_gui_cpp/test/test_flake8.py
@@ -1,0 +1,23 @@
+# Copyright 2017 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ament_flake8.main import main
+import pytest
+
+
+@pytest.mark.flake8
+@pytest.mark.linter
+def test_flake8():
+    rc = main(argv=[])
+    assert rc == 0, 'Found errors'

--- a/qt_gui_cpp/test/test_pep257.py
+++ b/qt_gui_cpp/test/test_pep257.py
@@ -1,0 +1,23 @@
+# Copyright 2015 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ament_pep257.main import main
+import pytest
+
+
+@pytest.mark.linter
+@pytest.mark.pep257
+def test_pep257():
+    rc = main(argv=['.', 'test'])
+    assert rc == 0, 'Found code style errors / warnings'

--- a/qt_gui_py_common/CMakeLists.txt
+++ b/qt_gui_py_common/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.5)
 project(qt_gui_py_common)
 
 find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_python REQUIRED)
 
 ament_python_install_package(${PROJECT_NAME}
   PACKAGE_DIR src/${PROJECT_NAME})
@@ -12,5 +13,15 @@ install(DIRECTORY resource
 install(TARGETS ${_library_name}
   DESTINATION "${PYTHON_INSTALL_DIR}/${PROJECT_NAME}"
 )
+
+if(BUILD_TESTING)
+  find_package(ament_cmake_pytest REQUIRED)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+
+  ament_add_pytest_test(${PROJECT_NAME} test
+    APPEND_ENV PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}
+    TIMEOUT 90)
+endif()
 
 ament_package()

--- a/qt_gui_py_common/package.xml
+++ b/qt_gui_py_common/package.xml
@@ -18,6 +18,12 @@
   <exec_depend>ament_index_python</exec_depend>
   <exec_depend>python_qt_binding</exec_depend>
 
+  <test_depend>ament_cmake_pytest</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_flake8</test_depend>
+  <test_depend>ament_pep257</test_depend>
+  <test_depend>python3-pytest</test_depend>
+  
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/qt_gui_py_common/src/qt_gui_py_common/simple_settings_dialog.py
+++ b/qt_gui_py_common/src/qt_gui_py_common/simple_settings_dialog.py
@@ -32,10 +32,10 @@
 
 import os
 
+from ament_index_python.resources import get_resource
 from python_qt_binding import loadUi
 from python_qt_binding.QtCore import qWarning
 from python_qt_binding.QtWidgets import QDialog, QLabel
-from ament_index_python.resources import get_resource
 
 from .checkbox_group import CheckBoxGroup
 from .exclusive_options_group import ExclusiveOptionGroup

--- a/qt_gui_py_common/test/test_flake8.py
+++ b/qt_gui_py_common/test/test_flake8.py
@@ -1,0 +1,23 @@
+# Copyright 2017 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ament_flake8.main import main
+import pytest
+
+
+@pytest.mark.flake8
+@pytest.mark.linter
+def test_flake8():
+    rc = main(argv=[])
+    assert rc == 0, 'Found errors'

--- a/qt_gui_py_common/test/test_pep257.py
+++ b/qt_gui_py_common/test/test_pep257.py
@@ -1,0 +1,23 @@
+# Copyright 2015 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ament_pep257.main import main
+import pytest
+
+
+@pytest.mark.linter
+@pytest.mark.pep257
+def test_pep257():
+    rc = main(argv=['.', 'test'])
+    assert rc == 0, 'Found code style errors / warnings'


### PR DESCRIPTION
This adds style tests and updates the existing qt_dotgraph tests to pass. It does rely on python_qt_binding pull request (https://github.com/ros-visualization/python_qt_binding/pull/53)