### PR TITLE
Modifying qt_gui_cpp to fix build errors in rqt_gui_core

### DIFF
--- a/qt_gui_cpp/CMakeLists.txt
+++ b/qt_gui_cpp/CMakeLists.txt
@@ -14,13 +14,14 @@ add_subdirectory(src)
 
 install(FILES plugin.xml
   DESTINATION share)
+
 install(
-    DIRECTORY include
-    DESTINATION include
-  )
+  DIRECTORY include
+  DESTINATION include
+)
 
 ament_export_dependencies(pluginlib)
-ament_export_dependencies(TinyXML)
+ament_export_include_directories(include)
 
 ament_export_include_directories(include)
 ament_export_libraries(${PROJECT_NAME})

--- a/qt_gui_cpp/package.xml
+++ b/qt_gui_cpp/package.xml
@@ -35,7 +35,6 @@
   <test_depend>ament_pep257</test_depend>
   <test_depend>python3-pytest</test_depend>
 
-
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/qt_gui_cpp/package.xml
+++ b/qt_gui_cpp/package.xml
@@ -34,7 +34,7 @@
   <test_depend>ament_flake8</test_depend>
   <test_depend>ament_pep257</test_depend>
   <test_depend>python3-pytest</test_depend>
-  
+
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
In order to build rqt_gui_cpp on top of qt_gui_cpp, we need to export the qt_gui_cpp libraries