### PR TITLE
fixing simple_settings_ui path

### DIFF
--- a/qt_gui_py_common/src/qt_gui_py_common/simple_settings_dialog.py
+++ b/qt_gui_py_common/src/qt_gui_py_common/simple_settings_dialog.py
@@ -49,7 +49,8 @@ class SimpleSettingsDialog(QDialog):
         self.setObjectName('SimpleSettingsDialog')
 
         _, package_path = get_resource('packages', 'qt_gui_py_common')
-        ui_file = os.path.join(package_path, 'share', 'resource', 'simple_settings_dialog.ui')
+        ui_file = os.path.join(
+            package_path, 'share', 'qt_gui_py_common', 'resource', 'simple_settings_dialog.ui')
         loadUi(ui_file, self)
 
         self.setWindowTitle(title)


### PR DESCRIPTION
Addresses: https://github.com/ros-visualization/rqt_py_console/issues/4

Fixing the simple_settings_dialog.ui path