### PR TITLE
Fixing warning message

### DIFF
--- a/qt_gui/src/qt_gui/plugin_manager.py
+++ b/qt_gui/src/qt_gui/plugin_manager.py
@@ -280,7 +280,7 @@ class PluginManager(QObject):
             else:
                 qCritical('PluginManager._load_plugin() could not load plugin "%s"%s' %
                           (instance_id.plugin_id, (':\n%s' % traceback.format_exc() if
-                           not exception else '')))
+                           isinstance(exception, Exception) else '')))
             self._remove_running_plugin(instance_id)
             # quit embed application
             if self._application_context.options.embed_plugin:


### PR DESCRIPTION
This bug cropped up during the flake8 fixes. Before, it tested if ```exception != True``` which is not the same as ```not exception```. I believe the intention was to print the stack trace if the exception was an instance of an actual exception and not just a boolean 'True'.