### PR TITLE
Ros2 port windows

### DIFF
--- a/qt_gui_cpp/src/qt_gui_cpp/CMakeLists.txt
+++ b/qt_gui_cpp/src/qt_gui_cpp/CMakeLists.txt
@@ -1,8 +1,9 @@
 set(Python_ADDITIONAL_VERSIONS "${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}")
 find_package(PythonLibs "${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}" REQUIRED)
 find_package(Qt5Widgets REQUIRED)
-
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
+endif()
 
 set(qt_gui_cpp_SRCS
   composite_plugin_provider.cpp
@@ -37,8 +38,16 @@ ament_export_dependencies(pluginlib)
 include_directories(${PROJECT_NAME} ${qt_gui_cpp_INCLUDE_DIRECTORIES} ${pluginlib_INCLUDE_DIRS})
 add_library(${PROJECT_NAME} ${qt_gui_cpp_SRCS} ${qt_gui_cpp_MOCS})
 
+if (WIN32)
+  # On Windows systems, Visual Studio does not currently set __cplusplus correctly unless this
+  # compile option is added. __cplusplus is used by a header in pluginlib/class_loader.hpp
+  message(STATUS "On Windows, setting /Zc:__cplusplus")
+  target_compile_options(${PROJECT_NAME} PUBLIC "/Zc:__cplusplus")
+endif()
+
 target_link_libraries(${PROJECT_NAME} ${qt_gui_cpp_LINK_LIBRARIES} ${ament_LIBRARIES} Qt5::Widgets ${TinyXML2_LIBRARIES})
 
 install(TARGETS ${PROJECT_NAME}
   ARCHIVE DESTINATION lib
-  LIBRARY DESTINATION lib)
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin)

--- a/qt_gui_cpp/src/qt_gui_cpp_sip/CMakeLists.txt
+++ b/qt_gui_cpp/src/qt_gui_cpp_sip/CMakeLists.txt
@@ -29,7 +29,7 @@ set(qt_gui_cpp_sip_DEPENDENT_FILES
 # maintain context for different named target
 set(qt_gui_cpp_sip_INCLUDE_DIRS ${qt_gui_cpp_INCLUDE_DIRS} "${CMAKE_CURRENT_SOURCE_DIR}/../../include")
 set(qt_gui_cpp_sip_LIBRARY_DIRS ${qt_gui_cpp_LIBRARY_DIRS} lib)
-set(qt_gui_cpp_sip_LDFLAGS_OTHER ${qt_gui_cpp_LDFLAGS_OTHER} -Wl,-rpath,\\"lib\\")
+set(qt_gui_cpp_sip_LDFLAGS_OTHER ${qt_gui_cpp_LDFLAGS_OTHER})
 
 set(_qt_gui_cpp_sip_LIBRARIES
   ${pluginlib_LIBRARIES}
@@ -71,6 +71,8 @@ if(sip_helper_FOUND)
 
   if(APPLE)
     set(LIBQT_GUI_CPP_SIP_SUFFIX .so)
+  elseif(WIN32)
+    set(LIBQT_GUI_CPP_SIP_SUFFIX .pyd)
   else()
     set(LIBQT_GUI_CPP_SIP_SUFFIX ${CMAKE_SHARED_LIBRARY_SUFFIX})
   endif()


### PR DESCRIPTION
This provides the necessary changes to qt_gui_core to build and run on windows.

Depends on PRs #147, #148, #150 

New commit: https://github.com/ros-visualization/qt_gui_core/pull/146/commits/29b23ba1d6d58fa2d40fc2d7bdf9ca186ba2060e