### PR TITLE
Migrate tinyxml2

### DIFF
--- a/qt_gui_cpp/CMakeLists.txt
+++ b/qt_gui_cpp/CMakeLists.txt
@@ -3,12 +3,12 @@ project(qt_gui_cpp)
 
 find_package(ament_cmake REQUIRED)
 find_package(pluginlib REQUIRED)
-find_package(tinyxml_vendor REQUIRED)
+find_package(tinyxml2_vendor REQUIRED)
 
 ament_python_install_package(${PROJECT_NAME}
   PACKAGE_DIR src/${PROJECT_NAME})
 
-include_directories(include ${TinyXML_INCLUDE_DIRS} ${pluginlib_INCLUDE_DIRS})
+include_directories(include ${TinyXML2_INCLUDE_DIRS} ${pluginlib_INCLUDE_DIRS})
 
 add_subdirectory(src)
 

--- a/qt_gui_cpp/package.xml
+++ b/qt_gui_cpp/package.xml
@@ -21,13 +21,11 @@
   <build_depend version_gte="0.3.0">python_qt_binding</build_depend>
   <build_depend>qt5-qmake</build_depend>
   <build_depend>qtbase5-dev</build_depend>
-  <build_depend>tinyxml_vendor</build_depend>
-  <build_depend>tinyxml</build_depend>
+  <build_depend>tinyxml2_vendor</build_depend>
 
   <exec_depend version_gte="1.9.23">pluginlib</exec_depend>
   <exec_depend version_gte="0.3.0">qt_gui</exec_depend>
-  <exec_depend>tinyxml_vendor</exec_depend>
-  <exec_depend>tinyxml</exec_depend>
+  <exec_depend>tinyxml2_vendor</exec_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/qt_gui_cpp/src/qt_gui_cpp/CMakeLists.txt
+++ b/qt_gui_cpp/src/qt_gui_cpp/CMakeLists.txt
@@ -37,7 +37,7 @@ ament_export_dependencies(pluginlib)
 include_directories(${PROJECT_NAME} ${qt_gui_cpp_INCLUDE_DIRECTORIES} ${pluginlib_INCLUDE_DIRS})
 add_library(${PROJECT_NAME} ${qt_gui_cpp_SRCS} ${qt_gui_cpp_MOCS})
 
-target_link_libraries(${PROJECT_NAME} ${qt_gui_cpp_LINK_LIBRARIES} ${ament_LIBRARIES} Qt5::Widgets ${TinyXML_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${qt_gui_cpp_LINK_LIBRARIES} ${ament_LIBRARIES} Qt5::Widgets ${TinyXML2_LIBRARIES})
 
 install(TARGETS ${PROJECT_NAME}
   ARCHIVE DESTINATION lib


### PR DESCRIPTION
This migrates the TinyXml dependency to TinyXMl2, which is better supported by ROS2 across the different platforms (esp Windows).