### PR TITLE
Adding test for importing sip generated library

### DIFF
--- a/qt_gui_cpp/CMakeLists.txt
+++ b/qt_gui_cpp/CMakeLists.txt
@@ -29,4 +29,12 @@ ament_export_libraries(${PROJECT_NAME})
 # TODO(brawner) add ament_lint_auto tests here. Much of the c++ code needs to
 # be updated for ROS2 style
 
+if(BUILD_TESTING)
+  find_package(ament_cmake_pytest REQUIRED)
+
+  ament_add_pytest_test(qt_gui_cpp test
+    APPEND_ENV PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}
+    TIMEOUT 90)
+endif()
+
 ament_package(CONFIG_EXTRAS cmake/${PROJECT_NAME}-extras.cmake)

--- a/qt_gui_cpp/package.xml
+++ b/qt_gui_cpp/package.xml
@@ -29,6 +29,8 @@
   <exec_depend>tinyxml_vendor</exec_depend>
   <exec_depend>tinyxml</exec_depend>
 
+  <test_depend>ament_cmake_pytest</test_depend>
+  
   <export>
     <build_type>ament_cmake</build_type>
     <qt_gui plugin="${prefix}/plugin.xml"/>

--- a/qt_gui_cpp/test/test_imports.py
+++ b/qt_gui_cpp/test/test_imports.py
@@ -1,0 +1,18 @@
+# Copyright 2018, PickNik Consulting
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def test_import_libqt_gui_cpp_sip():
+    from qt_gui_cpp import libqt_gui_cpp_sip
+    assert libqt_gui_cpp_sip is not None


### PR DESCRIPTION
This adds a test to qt_gui_cpp to ensure that libqt_gui_cpp_sip is importable.

Here is an example where it fails (this branch)
https://ci.ros2.org/job/ci_linux/5720/console

Here is an example where it passes (ros2_port_windows with this commit cherry-picked)
https://ci.ros2.org/job/ci_linux/5721/console