### PR TITLE
Add tango icons

### DIFF
--- a/qt_gui/package.xml
+++ b/qt_gui/package.xml
@@ -23,7 +23,7 @@
   <exec_depend>ament_index_python</exec_depend>
   <exec_depend>python_qt_binding</exec_depend>
   <exec_depend>python3-catkin-pkg-modules</exec_depend>
-  <exec_depend>tango-icon-theme</exec_depend>
+  <exec_depend>qt_gui_icons</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/qt_gui/src/qt_gui/main.py
+++ b/qt_gui/src/qt_gui/main.py
@@ -193,19 +193,17 @@ class Main(object):
 
     def _check_icon_theme_compliance(self):
         from python_qt_binding.QtGui import QIcon
-        # TODO find a better way to verify Theme standard compliance
-        if QIcon.themeName() == '' or \
-           QIcon.fromTheme('document-save').isNull() or \
-           QIcon.fromTheme('document-open').isNull() or \
-           QIcon.fromTheme('edit-cut').isNull() or \
-           QIcon.fromTheme('object-flip-horizontal').isNull():
-            if 'darwin' in platform.platform().lower() and \
-                    '/usr/local/share/icons' not in QIcon.themeSearchPaths():
-                QIcon.setThemeSearchPaths(QIcon.themeSearchPaths() + ['/usr/local/share/icons'])
-            original_theme = QIcon.themeName()
+        required_icons = ['document-save', 'document-open', 'edit-cut', 'object-flip-horizontal']
+        current_theme_is_valid = True
+        for icon_name in required_icons:
+            if QIcon.fromTheme(icon_name).isNull():
+                current_theme_is_valid = False
+
+        if not current_theme_is_valid:
+            _, icons_pkg_path = get_resource('packages', 'qt_gui_icons')
+            icons_path = os.path.join(icons_pkg_path, 'share', 'qt_gui_icons', 'resource', 'icons')
+            QIcon.setThemeSearchPaths(QIcon.themeSearchPaths() + [icons_path, ])
             QIcon.setThemeName('Tango')
-            if QIcon.fromTheme('document-save').isNull():
-                QIcon.setThemeName(original_theme)
 
     def create_application(self, argv):
         from python_qt_binding.QtCore import Qt


### PR DESCRIPTION
In order to show icons on Mac and Windows systems, a compliant icon theme needs to be installed or included. Tango can be installed on Linux OSs and on MacOS, but on Windows there aren't any current projects. This PR adds the scalable icons. 

The logic in qt_gui.main was changed in this commit https://github.com/ros-visualization/qt_gui_core/commit/4ccca02ab17bcc6a5ac33ab2739705dc36678ef5
The files were added in a separate commit. 

This addresses issue #154 