### PR TITLE
Fixes for windows

### DIFF
--- a/qt_gui_cpp/CMakeLists.txt
+++ b/qt_gui_cpp/CMakeLists.txt
@@ -3,12 +3,6 @@ project(qt_gui_cpp)
 
 find_package(ament_cmake REQUIRED)
 
-if(WIN32)
-  message(STATUS "qt_gui_coo is not yet supported on Windows. Package will not be built.")
-  ament_package()
-  return()
-endif()
-
 find_package(pluginlib REQUIRED)
 find_package(tinyxml2_vendor REQUIRED)
 
@@ -28,8 +22,6 @@ install(
 )
 
 ament_export_dependencies(pluginlib)
-ament_export_include_directories(include)
-
 ament_export_include_directories(include)
 ament_export_libraries(${PROJECT_NAME})
 

--- a/qt_gui_cpp/src/qt_gui_cpp_sip/CMakeLists.txt
+++ b/qt_gui_cpp/src/qt_gui_cpp_sip/CMakeLists.txt
@@ -41,8 +41,8 @@ set(_qt_gui_cpp_sip_LIBRARIES
 foreach(_lib_name ${_qt_gui_cpp_sip_LIBRARIES})
   if(TARGET ${_lib_name})
     # Use a nifty cmake generator expression to resolve the target location
-    list(APPEND qt_gui_cpp_sip_LIBRARIES $<TARGET_FILE:${_lib_name}>)
-  else()
+    list(APPEND qt_gui_cpp_sip_LIBRARIES $<TARGET_LINKER_FILE:${_lib_name}>)
+  elseif(EXISTS ${_lib_name} OR ${_lib_name} STREQUAL "stdc++fs")
     # This library should work as is
     list(APPEND qt_gui_cpp_sip_LIBRARIES ${_lib_name})
   endif()


### PR DESCRIPTION
The ```$<TARGET_FILE:${_lib_name}>``` expression pulled in the .dlls which cannot be linked against. Instead Windows needs the .lib files.

Furthermore, ```TINYXML2_LIBRARIES``` still contains library name that aren't legitimate and aren't targets. So I've added in the EXIST check.

```-- TINYXML2_LIBRARIES=debug;C:/ProgramData/chocolatey/lib/tinyxml2/lib/tinyxml2d.lib;optimized;C:/ProgramData/chocolatey/lib/tinyxml2/lib/tinyxml2.lib
```