### PR TITLE
support building on Xenial with TinyXML2 version 2.2

### DIFF
--- a/qt_gui_cpp/CMakeLists.txt
+++ b/qt_gui_cpp/CMakeLists.txt
@@ -1,6 +1,11 @@
 cmake_minimum_required(VERSION 3.5)
 project(qt_gui_cpp)
 
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+
 find_package(ament_cmake REQUIRED)
 
 if(WIN32)


### PR DESCRIPTION
Follow up of #147.

@brawner FYI

[![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=6066)](https://ci.ros2.org/job/ci_linux/6066/)