### PR TITLE
[Windows][kinetic] Add missing DLL exports for qt_gui_cpp

### DIFF
--- a/qt_gui_cpp/include/qt_gui_cpp/exports.h
+++ b/qt_gui_cpp/include/qt_gui_cpp/exports.h
@@ -1,35 +1,3 @@
-/*
- * Copyright (c) 2019, Dirk Thomas, TU Darmstadt
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *
- *   * Redistributions of source code must retain the above copyright
- *     notice, this list of conditions and the following disclaimer.
- *   * Redistributions in binary form must reproduce the above
- *     copyright notice, this list of conditions and the following
- *     disclaimer in the documentation and/or other materials provided
- *     with the distribution.
- *   * Neither the name of the TU Darmstadt nor the names of its
- *     contributors may be used to endorse or promote products derived
- *     from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
-
 #ifndef qt_gui_cpp__EXPORTS_H
 #define qt_gui_cpp__EXPORTS_H
 

--- a/qt_gui_cpp/include/qt_gui_cpp/exports.h
+++ b/qt_gui_cpp/include/qt_gui_cpp/exports.h
@@ -1,3 +1,34 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the TU Darmstadt nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
 #ifndef qt_gui_cpp__EXPORTS_H
 #define qt_gui_cpp__EXPORTS_H
 

--- a/qt_gui_cpp/include/qt_gui_cpp/exports.h
+++ b/qt_gui_cpp/include/qt_gui_cpp/exports.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2011, Dirk Thomas, TU Darmstadt
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the TU Darmstadt nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef qt_gui_cpp__EXPORTS_H
+#define qt_gui_cpp__EXPORTS_H
+
+/*
+  Windows import/export and gnu http://gcc.gnu.org/wiki/Visibility
+  macros.
+ */
+#if defined(_MSC_VER)
+    #define QT_GUI_CPP_HELPER_IMPORT __declspec(dllimport)
+    #define QT_GUI_CPP_HELPER_EXPORT __declspec(dllexport)
+    #define QT_GUI_CPP_HELPER_LOCAL
+#elif __GNUC__ >= 4
+    #define QT_GUI_CPP_HELPER_IMPORT __attribute__ ((visibility("default")))
+    #define QT_GUI_CPP_HELPER_EXPORT __attribute__ ((visibility("default")))
+    #define QT_GUI_CPP_HELPER_LOCAL  __attribute__ ((visibility("hidden")))
+#else
+    #define QT_GUI_CPP_HELPER_IMPORT
+    #define QT_GUI_CPP_HELPER_EXPORT
+    #define QT_GUI_CPP_HELPER_LOCAL
+#endif
+
+#ifdef ROS_BUILD_SHARED_LIBS // ros is being built around shared libraries
+  #ifdef qt_gui_cpp_EXPORTS // we are building a shared lib/dll
+    #define QT_GUI_CPP_DECL QT_GUI_CPP_HELPER_EXPORT
+  #else // we are using shared lib/dll
+    #define QT_GUI_CPP_DECL QT_GUI_CPP_HELPER_IMPORT
+  #endif
+#else // ros is being built around static libraries
+  #define QT_GUI_CPP_DECL
+#endif
+
+#endif

--- a/qt_gui_cpp/include/qt_gui_cpp/exports.h
+++ b/qt_gui_cpp/include/qt_gui_cpp/exports.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, Dirk Thomas, TU Darmstadt
+ * Copyright (c) 2019, Dirk Thomas, TU Darmstadt
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qt_gui_cpp/include/qt_gui_cpp/plugin.h
+++ b/qt_gui_cpp/include/qt_gui_cpp/plugin.h
@@ -36,6 +36,7 @@
 #include "plugin_bridge.h"
 #include "plugin_context.h"
 #include "settings.h"
+#include "exports.h"
 
 #include <QObject>
 
@@ -45,7 +46,7 @@ namespace qt_gui_cpp
 /**
  * The base class for C++ plugins.
  */
-class Plugin
+class QT_GUI_CPP_DECL Plugin
   : public QObject
 {
 

--- a/qt_gui_cpp/include/qt_gui_cpp/plugin_bridge.h
+++ b/qt_gui_cpp/include/qt_gui_cpp/plugin_bridge.h
@@ -33,6 +33,8 @@
 #ifndef qt_gui_cpp__PluginBridge_H
 #define qt_gui_cpp__PluginBridge_H
 
+#include "exports.h"
+
 #include <QObject>
 
 namespace qt_gui_cpp
@@ -42,7 +44,7 @@ class Plugin;
 class PluginContext;
 class PluginProvider;
 
-class PluginBridge
+class QT_GUI_CPP_DECL PluginBridge
   : public QObject
 {
 

--- a/qt_gui_cpp/include/qt_gui_cpp/plugin_context.h
+++ b/qt_gui_cpp/include/qt_gui_cpp/plugin_context.h
@@ -34,6 +34,7 @@
 #define qt_gui_cpp__PluginContext_H
 
 #include "generic_proxy.h"
+#include "exports.h"
 
 #include <QMap>
 #include <QObject>
@@ -49,7 +50,7 @@ namespace qt_gui_cpp
  * PluginContext providing information to the plugin and exposing methods for the plugin to interact with the framework.
  * It relays all methods to the corresponding plugin handler.
  */
-class PluginContext
+class QT_GUI_CPP_DECL PluginContext
   : public QObject
 {
 

--- a/qt_gui_cpp/include/qt_gui_cpp/ros_pluginlib_plugin_provider_for_plugin_providers.h
+++ b/qt_gui_cpp/include/qt_gui_cpp/ros_pluginlib_plugin_provider_for_plugin_providers.h
@@ -35,6 +35,9 @@
 
 #include "plugin_provider.h"
 #include "ros_pluginlib_plugin_provider.h"
+#include "exports.h"
+
+template class QT_GUI_CPP_DECL qt_gui_cpp::RosPluginlibPluginProvider<qt_gui_cpp::PluginProvider>;
 
 namespace qt_gui_cpp
 {

--- a/qt_gui_cpp/include/qt_gui_cpp/ros_pluginlib_plugin_provider_for_plugins.h
+++ b/qt_gui_cpp/include/qt_gui_cpp/ros_pluginlib_plugin_provider_for_plugins.h
@@ -35,6 +35,9 @@
 
 #include "plugin.h"
 #include "ros_pluginlib_plugin_provider.h"
+#include "exports.h"
+
+template class QT_GUI_CPP_DECL qt_gui_cpp::RosPluginlibPluginProvider<qt_gui_cpp::Plugin>;
 
 namespace qt_gui_cpp
 {

--- a/qt_gui_cpp/src/qt_gui_cpp/CMakeLists.txt
+++ b/qt_gui_cpp/src/qt_gui_cpp/CMakeLists.txt
@@ -13,6 +13,7 @@ set(qt_gui_cpp_SRCS
   plugin_descriptor.cpp
   plugin_provider.cpp
   recursive_plugin_provider.cpp
+  ros_pluginlib_plugin_provider.cpp
   settings.cpp
 )
 

--- a/qt_gui_cpp/src/qt_gui_cpp/ros_pluginlib_plugin_provider.cpp
+++ b/qt_gui_cpp/src/qt_gui_cpp/ros_pluginlib_plugin_provider.cpp
@@ -1,3 +1,34 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the TU Darmstadt nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
 #include "plugin_provider.h"
 #include "plugin.h"
 #include "ros_pluginlib_plugin_provider.h"

--- a/qt_gui_cpp/src/qt_gui_cpp/ros_pluginlib_plugin_provider.cpp
+++ b/qt_gui_cpp/src/qt_gui_cpp/ros_pluginlib_plugin_provider.cpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2011, Dirk Thomas, TU Darmstadt
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the TU Darmstadt nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "plugin_provider.h"
+#include "plugin.h"
+#include "ros_pluginlib_plugin_provider.h"
+#include "exports.h"
+
+// Explicit instantiation with export declaration for Windows.
+template class QT_GUI_CPP_DECL qt_gui_cpp::RosPluginlibPluginProvider<qt_gui_cpp::Plugin>;
+template class QT_GUI_CPP_DECL qt_gui_cpp::RosPluginlibPluginProvider<qt_gui_cpp::PluginProvider>;

--- a/qt_gui_cpp/src/qt_gui_cpp/ros_pluginlib_plugin_provider.cpp
+++ b/qt_gui_cpp/src/qt_gui_cpp/ros_pluginlib_plugin_provider.cpp
@@ -1,35 +1,3 @@
-/*
- * Copyright (c) 2019, Dirk Thomas, TU Darmstadt
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *
- *   * Redistributions of source code must retain the above copyright
- *     notice, this list of conditions and the following disclaimer.
- *   * Redistributions in binary form must reproduce the above
- *     copyright notice, this list of conditions and the following
- *     disclaimer in the documentation and/or other materials provided
- *     with the distribution.
- *   * Neither the name of the TU Darmstadt nor the names of its
- *     contributors may be used to endorse or promote products derived
- *     from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
-
 #include "plugin_provider.h"
 #include "plugin.h"
 #include "ros_pluginlib_plugin_provider.h"

--- a/qt_gui_cpp/src/qt_gui_cpp/ros_pluginlib_plugin_provider.cpp
+++ b/qt_gui_cpp/src/qt_gui_cpp/ros_pluginlib_plugin_provider.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, Dirk Thomas, TU Darmstadt
+ * Copyright (c) 2019, Dirk Thomas, TU Darmstadt
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
Add missing DLL exports for the qt_gui_cpp project.

The build is verified by https://aka.ms/ros project.