### PR TITLE
remove version as it's deprecated and generate stderr output

### DIFF
--- a/qt_gui_cpp/src/qt_gui_cpp_sip/qt_gui_cpp.sip
+++ b/qt_gui_cpp/src/qt_gui_cpp_sip/qt_gui_cpp.sip
@@ -1,4 +1,4 @@
-%Module libqt_gui_cpp_sip 1
+%Module libqt_gui_cpp_sip
 
 %Import QtCore/QtCoremod.sip
 %Import QtGui/QtGuimod.sip


### PR DESCRIPTION
This PR removes the `libqt_gui_cpp_sip` version number completely to get rid of deprecation warnings and as it's not supported anymore.
From https://www.riverbankcomputing.com/static/Docs/sip/directives.html#directive-%Module

> This is deprecated and ignored in SIP v4.19.

---

Context:

When building ROS 2 crystal the following message is printed to stderr
```
sip: Deprecation warning: qt_gui_cpp.sip:1: %Module version number should be specified using the 'version' argument
```
If using the version argument as suggested:
```
%Module(name=libqt_gui_cpp_sip, version=1)
```
The message becomes:
```
sip: Deprecation warning: qt_gui_cpp.sip:1: %Module version numbers are deprecated and ignored
```
This deprecation is since 4.19, which is the version present [in bionic](https://packages.ubuntu.com/bionic/python3-sip-dev).