### PR TITLE
[ros2] add missing QtCore import

### DIFF
--- a/qt_gui/src/qt_gui/perspective_manager.py
+++ b/qt_gui/src/qt_gui/perspective_manager.py
@@ -423,6 +423,7 @@ class PerspectiveManager(QObject):
             self._convert_values(groups[group], convert_function)
 
     def _import_value(self, value):
+        import QtCore  # noqa: F401
         if value['type'] == 'repr':
             return eval(value['repr'])
         elif value['type'] == 'repr(QByteArray.hex)':


### PR DESCRIPTION
It seems that this import was removed to pass the style checkers in https://github.com/ros-visualization/qt_gui_core/pull/135/files#diff-40fec8c42e721ff3d08597a5d5b071e5L424

Without this patch `rqt_gui` fails to export perspectives: http://answers.ros.org/question/322656/rqt-on-ros2-cannot-export-perspective-qtcore-is-not-defined/

This patch can be applied to the kinetic-devel branch as well.