### PR TITLE
fix C++ Settings methods allKeys, childGroups, childKeys

### DIFF
--- a/qt_gui/src/qt_gui/settings.py
+++ b/qt_gui/src/qt_gui/settings.py
@@ -47,6 +47,7 @@ class Settings(QObject):
             prefix += '/'
         return Settings(self._settings_proxy, prefix + group)
 
+    @Slot(result='QStringList')
     def all_keys(self):
         return self._settings_proxy.all_keys(self._group)
 
@@ -54,9 +55,11 @@ class Settings(QObject):
 
 #    def begin_write_array(self):
 
+    @Slot(result='QStringList')
     def child_groups(self):
         return self._settings_proxy.child_groups(self._group)
 
+    @Slot(result='QStringList')
     def child_keys(self):
         return self._settings_proxy.child_keys(self._group)
 


### PR DESCRIPTION
Fixes part of #172. The remaining case: #183.