### PR TITLE
[Windows][kinetic-devel] rework for windows linkage fix.

### DIFF
--- a/qt_gui_cpp/include/qt_gui_cpp/plugin_provider.h
+++ b/qt_gui_cpp/include/qt_gui_cpp/plugin_provider.h
@@ -36,6 +36,7 @@
 #include "plugin.h"
 #include "plugin_context.h"
 #include "plugin_descriptor.h"
+#include "exports.h"
 
 #include <QList>
 #include <QMap>
@@ -44,7 +45,7 @@
 namespace qt_gui_cpp
 {
 
-class PluginProvider
+class QT_GUI_CPP_DECL PluginProvider
 {
 
 public:

--- a/qt_gui_cpp/include/qt_gui_cpp/ros_pluginlib_plugin_provider_for_plugin_providers.h
+++ b/qt_gui_cpp/include/qt_gui_cpp/ros_pluginlib_plugin_provider_for_plugin_providers.h
@@ -35,6 +35,9 @@
 
 #include "plugin_provider.h"
 #include "ros_pluginlib_plugin_provider.h"
+#include "exports.h"
+
+extern template class QT_GUI_CPP_DECL qt_gui_cpp::RosPluginlibPluginProvider<qt_gui_cpp::PluginProvider>;
 
 namespace qt_gui_cpp
 {

--- a/qt_gui_cpp/include/qt_gui_cpp/ros_pluginlib_plugin_provider_for_plugins.h
+++ b/qt_gui_cpp/include/qt_gui_cpp/ros_pluginlib_plugin_provider_for_plugins.h
@@ -35,6 +35,9 @@
 
 #include "plugin.h"
 #include "ros_pluginlib_plugin_provider.h"
+#include "exports.h"
+
+extern template class QT_GUI_CPP_DECL qt_gui_cpp::RosPluginlibPluginProvider<qt_gui_cpp::Plugin>;
 
 namespace qt_gui_cpp
 {


### PR DESCRIPTION
This is a rework for https://github.com/ros-visualization/qt_gui_core/pull/187, which reverted an earlier Windows change (https://github.com/ros-visualization/qt_gui_core/pull/170) which broke `Linux` `armhf` build. However, after the revert, we started to see Windows build break again, so I am attempting to rework the change to fix it.

In order to avoid the multiple definition, I am proposing to add `extern` for the forward declaration for the class template with DLL linkage specifier, which should avoid the more than one definition violation but still pass the DLL linkage information to the downstream project for Windows build.

As of the additional information, the reviewers can find the error messages below generated from `MSVC`, where you can see that without the DLL linkage information MSVC was attempting to compile `qt_gui_cpp::RosPluginlibPluginProvider<qt_gui_cpp::Plugin>` into the `qt_gui_cpp_sip` (so that's why it was trying to look for `tinyxml` for linkage) but not to link it against the copy from `qt_gui_cpp`.

```msvc
Generating Code...
	link /NOLOGO /DYNAMICBASE /NXCOMPAT /DLL /MANIFEST /MANIFESTFILE:"C:/catkin_ws/devel_isolated/qt_gui_cpp/lib/site-packages/qt_gui_cpp\libqt_gui_cpp_sip".pyd.manifest /SUBSYSTEM:WINDOWS /INCREMENTAL:NO /OUT:"C:/catkin_ws/devel_isolated/qt_gui_cpp/lib/site-packages/qt_gui_cpp\libqt_gui_cpp_sip".pyd @C:\Users\VSSADM~1\AppData\Local\Temp\nm7A2B.tmp
   Creating library C:\catkin_ws\devel_isolated\qt_gui_cpp\lib\site-packages\qt_gui_cpp\libqt_gui_cpp_sip.lib and object C:\catkin_ws\devel_isolated\qt_gui_cpp\lib\site-packages\qt_gui_cpp\libqt_gui_cpp_sip.exp
siplibqt_gui_cpp_sipqt_gui_cppRosPluginlibPluginProvider_ForPlugins.obj : error LNK2019: unresolved external symbol "public: virtual __cdecl TiXmlNode::~TiXmlNode(void)" (??1TiXmlNode@@UEAA@XZ) referenced in function "public: virtual __cdecl TiXmlDocument::~TiXmlDocument(void)" (??1TiXmlDocument@@UEAA@XZ)
siplibqt_gui_cpp_sipqt_gui_cppRosPluginlibPluginProvider_ForPluginProviders.obj : error LNK2001: unresolved external symbol "public: virtual __cdecl TiXmlNode::~TiXmlNode(void)" (??1TiXmlNode@@UEAA@XZ)
siplibqt_gui_cpp_sipqt_gui_cppRosPluginlibPluginProvider_ForPlugins.obj : error LNK2019: unresolved external symbol "public: class TiXmlElement const * __cdecl TiXmlNode::NextSiblingElement(char const *)const " (?NextSiblingElement@TiXmlNode@@QEBAPEBVTiXmlElement@@PEBD@Z) referenced in function "public: class TiXmlElement * __cdecl TiXmlNode::NextSiblingElement(char const *)" (?NextSiblingElement@TiXmlNode@@QEAAPEAVTiXmlElement@@PEBD@Z)
siplibqt_gui_cpp_sipqt_gui_cppRosPluginlibPluginProvider_ForPluginProviders.obj : error LNK2001: unresolved external symbol "public: class TiXmlElement const * __cdecl TiXmlNode::NextSiblingElement(char const *)const " (?NextSiblingElement@TiXmlNode@@QEBAPEBVTiXmlElement@@PEBD@Z)
siplibqt_gui_cpp_sipqt_gui_cppRosPluginlibPluginProvider_ForPlugins.obj : error LNK2019: unresolved external symbol "public: class TiXmlElement const * __cdecl TiXmlNode::FirstChildElement(char const *)const " (?FirstChildElement@TiXmlNode@@QEBAPEBVTiXmlElement@@PEBD@Z) referenced in function "public: class TiXmlElement * __cdecl TiXmlNode::FirstChildElement(char const *)" (?FirstChildElement@TiXmlNode@@QEAAPEAVTiXmlElement@@PEBD@Z)
siplibqt_gui_cpp_sipqt_gui_cppRosPluginlibPluginProvider_ForPluginProviders.obj : error LNK2001: unresolved external symbol "public: class TiXmlElement const * __cdecl TiXmlNode::FirstChildElement(char const *)const " (?FirstChildElement@TiXmlNode@@QEBAPEBVTiXmlElement@@PEBD@Z)
siplibqt_gui_cpp_sipqt_gui_cppRosPluginlibPluginProvider_ForPlugins.obj : error LNK2019: unresolved external symbol "public: char const * __cdecl TiXmlElement::Attribute(char const *)const " (?Attribute@TiXmlElement@@QEBAPEBDPEBD@Z) referenced in function "private: void __cdecl qt_gui_cpp::RosPluginlibPluginProvider<class qt_gui_cpp::Plugin>::parseActionAttributes(class TiXmlElement *,class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > const &,class QString &,class QString &,class QString &,class QString &)" (?parseActionAttributes@?$RosPluginlibPluginProvider@VPlugin@qt_gui_cpp@@@qt_gui_cpp@@AEAAXPEAVTiXmlElement@@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@AEAVQString@@222@Z)
siplibqt_gui_cpp_sipqt_gui_cppRosPluginlibPluginProvider_ForPluginProviders.obj : error LNK2001: unresolved external symbol "public: char const * __cdecl TiXmlElement::Attribute(char const *)const " (?Attribute@TiXmlElement@@QEBAPEBDPEBD@Z)
siplibqt_gui_cpp_sipqt_gui_cppRosPluginlibPluginProvider_ForPlugins.obj : error LNK2019: unresolved external symbol "public: char const * __cdecl TiXmlElement::GetText(void)const " (?GetText@TiXmlElement@@QEBAPEBDXZ) referenced in function "private: void __cdecl qt_gui_cpp::RosPluginlibPluginProvider<class qt_gui_cpp::Plugin>::parseActionAttributes(class TiXmlElement *,class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > const &,class QString &,class QString &,class QString &,class QString &)" (?parseActionAttributes@?$RosPluginlibPluginProvider@VPlugin@qt_gui_cpp@@@qt_gui_cpp@@AEAAXPEAVTiXmlElement@@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@AEAVQString@@222@Z)
siplibqt_gui_cpp_sipqt_gui_cppRosPluginlibPluginProvider_ForPluginProviders.obj : error LNK2001: unresolved external symbol "public: char const * __cdecl TiXmlElement::GetText(void)const " (?GetText@TiXmlElement@@QEBAPEBDXZ)
siplibqt_gui_cpp_sipqt_gui_cppRosPluginlibPluginProvider_ForPlugins.obj : error LNK2019: unresolved external symbol "public: __cdecl TiXmlDocument::TiXmlDocument(void)" (??0TiXmlDocument@@QEAA@XZ) referenced in function "private: bool __cdecl qt_gui_cpp::RosPluginlibPluginProvider<class qt_gui_cpp::Plugin>::parseManifest(class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > const &,class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > const &,class QString &,class QString &,class QString &,class QString &,class qt_gui_cpp::PluginDescriptor *)" (?parseManifest@?$RosPluginlibPluginProvider@VPlugin@qt_gui_cpp@@@qt_gui_cpp@@AEAA_NAEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@0AEAVQString@@111PEAVPluginDescriptor@2@@Z)
siplibqt_gui_cpp_sipqt_gui_cppRosPluginlibPluginProvider_ForPluginProviders.obj : error LNK2001: unresolved external symbol "public: __cdecl TiXmlDocument::TiXmlDocument(void)" (??0TiXmlDocument@@QEAA@XZ)
siplibqt_gui_cpp_sipqt_gui_cppRosPluginlibPluginProvider_ForPlugins.obj : error LNK2019: unresolved external symbol "public: bool __cdecl TiXmlDocument::LoadFile(char const *,enum TiXmlEncoding)" (?LoadFile@TiXmlDocument@@QEAA_NPEBDW4TiXmlEncoding@@@Z) referenced in function "public: bool __cdecl TiXmlDocument::LoadFile(class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > const &,enum TiXmlEncoding)" (?LoadFile@TiXmlDocument@@QEAA_NAEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@W4TiXmlEncoding@@@Z)
siplibqt_gui_cpp_sipqt_gui_cppRosPluginlibPluginProvider_ForPluginProviders.obj : error LNK2001: unresolved external symbol "public: bool __cdecl TiXmlDocument::LoadFile(char const *,enum TiXmlEncoding)" (?LoadFile@TiXmlDocument@@QEAA_NPEBDW4TiXmlEncoding@@@Z)
siplibqt_gui_cpp_sipqt_gui_cppRosPluginlibPluginProvider_ForPlugins.obj : error LNK2001: unresolved external symbol "public: virtual char const * __cdecl TiXmlDocument::Parse(char const *,class TiXmlParsingData *,enum TiXmlEncoding)" (?Parse@TiXmlDocument@@UEAAPEBDPEBDPEAVTiXmlParsingData@@W4TiXmlEncoding@@@Z)
siplibqt_gui_cpp_sipqt_gui_cppRosPluginlibPluginProvider_ForPluginProviders.obj : error LNK2001: unresolved external symbol "public: virtual char const * __cdecl TiXmlDocument::Parse(char const *,class TiXmlParsingData *,enum TiXmlEncoding)" (?Parse@TiXmlDocument@@UEAAPEBDPEBDPEAVTiXmlParsingData@@W4TiXmlEncoding@@@Z)
siplibqt_gui_cpp_sipqt_gui_cppRosPluginlibPluginProvider_ForPlugins.obj : error LNK2001: unresolved external symbol "public: virtual void __cdecl TiXmlDocument::Print(struct _iobuf *,int)const " (?Print@TiXmlDocument@@UEBAXPEAU_iobuf@@H@Z)
siplibqt_gui_cpp_sipqt_gui_cppRosPluginlibPluginProvider_ForPluginProviders.obj : error LNK2001: unresolved external symbol "public: virtual void __cdecl TiXmlDocument::Print(struct _iobuf *,int)const " (?Print@TiXmlDocument@@UEBAXPEAU_iobuf@@H@Z)
siplibqt_gui_cpp_sipqt_gui_cppRosPluginlibPluginProvider_ForPlugins.obj : error LNK2001: unresolved external symbol "public: virtual bool __cdecl TiXmlDocument::Accept(class TiXmlVisitor *)const " (?Accept@TiXmlDocument@@UEBA_NPEAVTiXmlVisitor@@@Z)
siplibqt_gui_cpp_sipqt_gui_cppRosPluginlibPluginProvider_ForPluginProviders.obj : error LNK2001: unresolved external symbol "public: virtual bool __cdecl TiXmlDocument::Accept(class TiXmlVisitor *)const " (?Accept@TiXmlDocument@@UEBA_NPEAVTiXmlVisitor@@@Z)
siplibqt_gui_cpp_sipqt_gui_cppRosPluginlibPluginProvider_ForPlugins.obj : error LNK2001: unresolved external symbol "protected: virtual class TiXmlNode * __cdecl TiXmlDocument::Clone(void)const " (?Clone@TiXmlDocument@@MEBAPEAVTiXmlNode@@XZ)
siplibqt_gui_cpp_sipqt_gui_cppRosPluginlibPluginProvider_ForPluginProviders.obj : error LNK2001: unresolved external symbol "protected: virtual class TiXmlNode * __cdecl TiXmlDocument::Clone(void)const " (?Clone@TiXmlDocument@@MEBAPEAVTiXmlNode@@XZ)
siplibqt_gui_cpp_sipqt_gui_cppRosPluginlibPluginProvider_ForPlugins.obj : error LNK2001: unresolved external symbol "protected: virtual void __cdecl TiXmlDocument::StreamIn(class std::basic_istream<char,struct std::char_traits<char> > *,class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > *)" (?StreamIn@TiXmlDocument@@MEAAXPEAV?$basic_istream@DU?$char_traits@D@std@@@std@@PEAV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@3@@Z)
siplibqt_gui_cpp_sipqt_gui_cppRosPluginlibPluginProvider_ForPluginProviders.obj : error LNK2001: unresolved external symbol "protected: virtual void __cdecl TiXmlDocument::StreamIn(class std::basic_istream<char,struct std::char_traits<char> > *,class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > *)" (?StreamIn@TiXmlDocument@@MEAAXPEAV?$basic_istream@DU?$char_traits@D@std@@@std@@PEAV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@3@@Z)
C:\catkin_ws\devel_isolated\qt_gui_cpp\lib\site-packages\qt_gui_cpp\libqt_gui_cpp_sip.pyd : fatal error LNK1120: 12 unresolved externals
```

And in additions to the multiple redefinition, one more change is to add the missing `QT_GUI_CPP_DECL` for `PluginProvider`, which was forgotten by me in the initial pull request (https://github.com/ros-visualization/qt_gui_core/pull/170).