### PR TITLE
make another test more flexible in terms of whitespaces

### DIFF
--- a/qt_dotgraph/test/pygraphviz_factory_test.py
+++ b/qt_dotgraph/test/pygraphviz_factory_test.py
@@ -31,6 +31,7 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+import re
 import unittest
 
 try:
@@ -99,12 +100,14 @@ class PygraphvizFactoryTest(unittest.TestCase):
         fac.add_node_to_graph(g, 'edge')
         fac.add_edge_to_graph(g, 'foo', 'edge')
         fac.add_subgraph_to_graph(g, 'graph')
-        snippets = ['strict digraph "" {\n\tgraph',
+        snippets = ['strict digraph "" { graph',
                     'foo',
                     'label=foo',
                     '"edge"',
                     'label="edge"',
                     'foo -> "edge"']
         result = fac.create_dot(g)
+        # get rid of version specific whitespaces
+        result = re.sub('[\n\t ]+', ' ', result)
         for sn in snippets:
             self.assertTrue(sn in result, '%s \nmissing in\n %s' % (sn, result))

--- a/qt_dotgraph/test/pygraphviz_factory_test.py
+++ b/qt_dotgraph/test/pygraphviz_factory_test.py
@@ -100,14 +100,15 @@ class PygraphvizFactoryTest(unittest.TestCase):
         fac.add_node_to_graph(g, 'edge')
         fac.add_edge_to_graph(g, 'foo', 'edge')
         fac.add_subgraph_to_graph(g, 'graph')
-        snippets = ['strict digraph "" { graph',
+        snippets = ['strict digraph { graph',
                     'foo',
                     'label=foo',
                     '"edge"',
                     'label="edge"',
                     'foo -> "edge"']
         result = fac.create_dot(g)
-        # get rid of version specific whitespaces
+        # get rid of version specific quotes / whitespaces
+        result = re.sub('""', ' ', result)
         result = re.sub('[\n\t ]+', ' ', result)
         for sn in snippets:
             self.assertTrue(sn in result, '%s \nmissing in\n %s' % (sn, result))


### PR DESCRIPTION
Similar to #191.

@cottsay Since this only fails on CentOS (https://ci.ros2.org/view/nightly/job/nightly_linux-centos_debug/207/testReport/(root)/projectroot/qt_dotgraph/) can you please try this patch and comment if it resolves the failing test.