### PR TITLE
Auto adjust main window if standalone

### DIFF
--- a/qt_gui/src/qt_gui/main.py
+++ b/qt_gui/src/qt_gui/main.py
@@ -562,8 +562,13 @@ class Main(object):
 
         # set initial size - only used without saved configuration
         if main_window is not None:
-            main_window.resize(600, 450)
-            main_window.move(100, 100)
+            # Adjust size to fit the widget if standalone (e.g. single plugin)
+            if standalone:
+                main_window.adjustSize()
+            # On "clean" startup set some size to fully display the menu bar
+            else:
+                main_window.resize(600, 450)
+                main_window.move(100, 100)
 
         # ensure that qt_gui/src is in sys.path
         src_path = os.path.realpath(os.path.join(os.path.dirname(__file__), '..'))


### PR DESCRIPTION
I was loading a small plugin and noticed that on the initial startup there was quite some space around it.
This PR auto adjusts on standalone mode.
