### PR TITLE
[Windows][kinetic-devel] Use the portable way to decide the line break.

### DIFF
--- a/qt_dotgraph/src/qt_dotgraph/pydotfactory.py
+++ b/qt_dotgraph/src/qt_dotgraph/pydotfactory.py
@@ -37,6 +37,7 @@ except ImportError:
     from urllib import quote
 
 import pydot
+import os
 
 
 # Reference implementation for a dotcode factory
@@ -174,4 +175,4 @@ class PydotFactory():
         if type(dot) != str:
             dot = dot.decode()
         # sadly pydot generates line wraps cutting between numbers
-        return dot.replace('\\\n', '')
+        return dot.replace('\\%s' % os.linesep, '')

--- a/qt_dotgraph/src/qt_dotgraph/pydotfactory.py
+++ b/qt_dotgraph/src/qt_dotgraph/pydotfactory.py
@@ -175,4 +175,4 @@ class PydotFactory():
         if type(dot) != str:
             dot = dot.decode()
         # sadly pydot generates line wraps cutting between numbers
-        return dot.replace('\\%s' % os.linesep, '')
+        return dot.replace('\\%s' % os.linesep, '').replace('\\\n', '')


### PR DESCRIPTION
Use the portable [`os.linesep`](https://docs.python.org/3/library/os.html#os.linesep) instead of hard-coded `\n` line break in `create_dot`. The long lines with line break are not really replaced on Windows environment.