### PR TITLE
qt_gui: use native default icon theme if suitable

### DIFF
--- a/qt_gui/src/qt_gui/main.py
+++ b/qt_gui/src/qt_gui/main.py
@@ -192,8 +192,7 @@ class Main(object):
     def _check_icon_theme_compliance(self):
         from python_qt_binding.QtGui import QIcon
         # TODO find a better way to verify Theme standard compliance
-        if QIcon.themeName() == '' or \
-           QIcon.fromTheme('document-save').isNull() or \
+        if QIcon.fromTheme('document-save').isNull() or \
            QIcon.fromTheme('document-open').isNull() or \
            QIcon.fromTheme('edit-cut').isNull() or \
            QIcon.fromTheme('object-flip-horizontal').isNull():


### PR DESCRIPTION
Currently, `qt_gui` checks if `QIcon::themeName()` is empty and, if that is the case, proceeds to set `Tango` as the icon theme. However, `QIcon::themeName()` can be empty, meaning "use the system default theme". This PR simply removes this check. If there is any motivation for the check I'm not aware of, please disregard.

On my system (KDE), this allows rqt to use the native icon theme (Breeze), resulting in a much more integrated look and feel.

We still have the other checks that make sure important icons are available.

This might also solve problems on Mac & Windows (#154), where Tango is not available, but I don't know if there is *any* default icon theme there.