### PR TITLE
Fix platform check for macOS in themeSearchPaths patching

### DIFF
--- a/qt_gui/src/qt_gui/main.py
+++ b/qt_gui/src/qt_gui/main.py
@@ -199,7 +199,7 @@ class Main(object):
            QIcon.fromTheme('document-open').isNull() or \
            QIcon.fromTheme('edit-cut').isNull() or \
            QIcon.fromTheme('object-flip-horizontal').isNull():
-            if 'darwin' == platform.system().lower() and \
+            if platform.system() == 'Darwin' and \
                     '/usr/local/share/icons' not in QIcon.themeSearchPaths():
                 QIcon.setThemeSearchPaths(QIcon.themeSearchPaths() + ['/usr/local/share/icons'])
             original_theme = QIcon.themeName()

--- a/qt_gui/src/qt_gui/main.py
+++ b/qt_gui/src/qt_gui/main.py
@@ -199,7 +199,7 @@ class Main(object):
            QIcon.fromTheme('document-open').isNull() or \
            QIcon.fromTheme('edit-cut').isNull() or \
            QIcon.fromTheme('object-flip-horizontal').isNull():
-            if 'darwin' in platform.platform().lower() and \
+            if 'darwin' == platform.system().lower() and \
                     '/usr/local/share/icons' not in QIcon.themeSearchPaths():
                 QIcon.setThemeSearchPaths(QIcon.themeSearchPaths() + ['/usr/local/share/icons'])
             original_theme = QIcon.themeName()


### PR DESCRIPTION
use `platform.system()` which returns `Darwin` instead of `platform.platform()` which returns fully qualified OS name and version, e.g. `macOS-10.15.3-x86_64-i386-64bit`

This change fixes themeSearchPaths patching that fixes icons loading on macOS

P.S.
I have tested this only on ROS 2 Eloquent Elusor and not sure which base branch to use, so pointing to `crystal-devel` for now. 

Before: 
![image](https://user-images.githubusercontent.com/3339485/75020444-9e17ea00-5447-11ea-94fc-3e4ae6c60166.png)


After:
![image](https://user-images.githubusercontent.com/3339485/75020430-98220900-5447-11ea-951a-b7d079fbba7c.png)

Combined with #205:
![image](https://user-images.githubusercontent.com/3339485/75020555-d6b7c380-5447-11ea-81b7-c26ccc71985e.png)
