### PR TITLE
Fix title bar buttons rendering on macOS

### DIFF
--- a/qt_gui/resource/dock_widget_title_bar.ui
+++ b/qt_gui/resource/dock_widget_title_bar.ui
@@ -100,6 +100,9 @@
      <property name="toolTip">
       <string>Toggle Dockable</string>
      </property>
+     <property name="styleSheet">
+      <string notr="true">text-align: center; padding: 0px; margin: 0px</string>
+     </property>
      <property name="text">
       <string>D</string>
      </property>
@@ -137,6 +140,9 @@
      <property name="toolTip">
       <string>Configuration</string>
      </property>
+     <property name="styleSheet">
+      <string notr="true">text-align: center; padding: 0px; margin: 0px</string>
+     </property>
      <property name="text">
       <string>C</string>
      </property>
@@ -167,6 +173,9 @@
      </property>
      <property name="toolTip">
       <string>Reload</string>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">text-align: center; padding: 0px; margin: 0px</string>
      </property>
      <property name="text">
       <string>R</string>
@@ -204,6 +213,9 @@
      </property>
      <property name="toolTip">
       <string>Help</string>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">text-align: center; padding: 0px; margin: 0px</string>
      </property>
      <property name="text">
       <string>?</string>
@@ -258,8 +270,11 @@
      <property name="toolTip">
       <string>Minimize</string>
      </property>
+     <property name="styleSheet">
+      <string notr="true">text-align: center; padding: 0px; margin: 0px</string>
+     </property>
      <property name="text">
-      <string>-</string>
+      <string>_</string>
      </property>
      <property name="iconSize">
       <size>
@@ -294,6 +309,9 @@
      </property>
      <property name="toolTip">
       <string>Toggle Floating</string>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">text-align: center; padding: 0px; margin: 0px</string>
      </property>
      <property name="text">
       <string>O</string>
@@ -331,6 +349,9 @@
      </property>
      <property name="toolTip">
       <string>Close</string>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">text-align: center; padding: 0px; margin: 0px</string>
      </property>
      <property name="text">
       <string>X</string>

--- a/qt_gui/resource/dock_widget_title_bar.ui
+++ b/qt_gui/resource/dock_widget_title_bar.ui
@@ -274,7 +274,7 @@
       <string notr="true">text-align: center; padding: 0px; margin: 0px</string>
      </property>
      <property name="text">
-      <string>_</string>
+      <string>-</string>
      </property>
      <property name="iconSize">
       <size>


### PR DESCRIPTION
Set styleSheet with zero margins and padding for buttons that prevents clipping on macOS

Before: 
![image](https://user-images.githubusercontent.com/3339485/75019789-62c8eb80-5446-11ea-8f8f-90d4a9cd3687.png)

After:
![image](https://user-images.githubusercontent.com/3339485/75019994-b6d3d000-5446-11ea-95b7-61a7680093e6.png)

Combined with #204 
![image](https://user-images.githubusercontent.com/3339485/75020103-e8e53200-5446-11ea-971b-d8b4006b9cfc.png)

---
On Linux this change doesn't have any visible difference

Linux before:
![image](https://user-images.githubusercontent.com/3339485/75020248-319ceb00-5447-11ea-9f0c-f576190f954d.png)


On Linux after:
![image](https://user-images.githubusercontent.com/3339485/75020198-1b8f2a80-5447-11ea-8d6f-13ccfc5344e4.png)
