### PR TITLE
Fix "wrong import order" flake8 failure

### DIFF
--- a/qt_dotgraph/src/qt_dotgraph/pydotfactory.py
+++ b/qt_dotgraph/src/qt_dotgraph/pydotfactory.py
@@ -36,8 +36,9 @@ try:
 except ImportError:
     from urllib import quote
 
-import pydot
 import os
+
+import pydot
 
 
 # Reference implementation for a dotcode factory


### PR DESCRIPTION
Introduced by https://github.com/ros-visualization/qt_gui_core/pull/200.

See for example: https://ci.ros2.org/view/nightly/job/nightly_linux_release/1461/testReport/junit/qt_dotgraph/flake8/I100____src_qt_dotgraph_pydotfactory_py_40_1_/