### PR TITLE
use setuptools instead of distutils

### DIFF
--- a/qt_dotgraph/package.xml
+++ b/qt_dotgraph/package.xml
@@ -13,6 +13,8 @@
   <author>Thibault Kruse</author>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
 
   <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-pydot</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-pydot</exec_depend>

--- a/qt_dotgraph/package.xml
+++ b/qt_dotgraph/package.xml
@@ -20,9 +20,9 @@
   <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
   <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
 
-  <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-pydot</exec_depend>
-  <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-pydot</exec_depend>
-  <exec_depend version_gte="0.3.0">python_qt_binding</exec_depend>
+  <run_depend condition="$ROS_PYTHON_VERSION == 2">python-pydot</run_depend>
+  <run_depend condition="$ROS_PYTHON_VERSION == 3">python3-pydot</run_depend>
+  <run_depend version_gte="0.3.0">python_qt_binding</run_depend>
 
   <test_depend condition="$ROS_PYTHON_VERSION == 2">python-pygraphviz</test_depend>
   <test_depend condition="$ROS_PYTHON_VERSION == 3">python3-pygraphviz</test_depend>

--- a/qt_dotgraph/package.xml
+++ b/qt_dotgraph/package.xml
@@ -20,9 +20,9 @@
   <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
   <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
 
-  <run_depend condition="$ROS_PYTHON_VERSION == 2">python-pydot</run_depend>
-  <run_depend condition="$ROS_PYTHON_VERSION == 3">python3-pydot</run_depend>
-  <run_depend version_gte="0.3.0">python_qt_binding</run_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-pydot</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-pydot</exec_depend>
+  <exec_depend version_gte="0.3.0">python_qt_binding</exec_depend>
 
   <test_depend condition="$ROS_PYTHON_VERSION == 2">python-pygraphviz</test_depend>
   <test_depend condition="$ROS_PYTHON_VERSION == 3">python3-pygraphviz</test_depend>

--- a/qt_dotgraph/package.xml
+++ b/qt_dotgraph/package.xml
@@ -1,3 +1,7 @@
+<?xml version="1.0"?>
+<?xml-model
+  href="http://download.ros.org/schema/package_format3.xsd"
+  schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>qt_dotgraph</name>
   <version>0.4.0</version>

--- a/qt_dotgraph/setup.py
+++ b/qt_dotgraph/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+from setuptools import setup
 
 from catkin_pkg.python_setup import generate_distutils_setup
 

--- a/qt_gui/package.xml
+++ b/qt_gui/package.xml
@@ -26,8 +26,8 @@
   <build_depend condition="$ROS_PYTHON_VERSION == 2">python-qt5-bindings</build_depend>
   <build_depend condition="$ROS_PYTHON_VERSION == 3">python3-qt5-bindings</build_depend>
 
-  <run_depend version_gte="0.3.0">python_qt_binding</run_depend>
-  <run_depend condition="$ROS_PYTHON_VERSION == 2">python-rospkg</run_depend>
-  <run_depend condition="$ROS_PYTHON_VERSION == 3">python3-rospkg</run_depend>
-  <run_depend>tango-icon-theme</run_depend>
+  <exec_depend version_gte="0.3.0">python_qt_binding</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-rospkg</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-rospkg</exec_depend>
+  <exec_depend>tango-icon-theme</exec_depend>
 </package>

--- a/qt_gui/package.xml
+++ b/qt_gui/package.xml
@@ -1,3 +1,7 @@
+<?xml version="1.0"?>
+<?xml-model
+  href="http://download.ros.org/schema/package_format3.xsd"
+  schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>qt_gui</name>
   <version>0.4.0</version>

--- a/qt_gui/package.xml
+++ b/qt_gui/package.xml
@@ -15,6 +15,8 @@
   <author>Dirk Thomas</author>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
 
   <build_depend>qt5-qmake</build_depend>
   <build_depend condition="$ROS_PYTHON_VERSION == 2">python-qt5-bindings</build_depend>

--- a/qt_gui/package.xml
+++ b/qt_gui/package.xml
@@ -26,8 +26,8 @@
   <build_depend condition="$ROS_PYTHON_VERSION == 2">python-qt5-bindings</build_depend>
   <build_depend condition="$ROS_PYTHON_VERSION == 3">python3-qt5-bindings</build_depend>
 
-  <exec_depend version_gte="0.3.0">python_qt_binding</exec_depend>
-  <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-rospkg</exec_depend>
-  <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-rospkg</exec_depend>
-  <exec_depend>tango-icon-theme</exec_depend>
+  <run_depend version_gte="0.3.0">python_qt_binding</run_depend>
+  <run_depend condition="$ROS_PYTHON_VERSION == 2">python-rospkg</run_depend>
+  <run_depend condition="$ROS_PYTHON_VERSION == 3">python3-rospkg</run_depend>
+  <run_depend>tango-icon-theme</run_depend>
 </package>

--- a/qt_gui/setup.py
+++ b/qt_gui/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup(

--- a/qt_gui_app/package.xml
+++ b/qt_gui_app/package.xml
@@ -1,4 +1,8 @@
-<package>
+<?xml version="1.0"?>
+<?xml-model
+  href="http://download.ros.org/schema/package_format3.xsd"
+  schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>qt_gui_app</name>
   <version>0.4.0</version>
   <description>

--- a/qt_gui_app/package.xml
+++ b/qt_gui_app/package.xml
@@ -13,6 +13,8 @@
   <author>Dirk Thomas</author>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
 
   <run_depend version_gte="0.3.0">qt_gui</run_depend>
 </package>

--- a/qt_gui_app/package.xml
+++ b/qt_gui_app/package.xml
@@ -20,5 +20,5 @@
   <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
   <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
 
-  <run_depend version_gte="0.3.0">qt_gui</run_depend>
+  <exec_depend version_gte="0.3.0">qt_gui</exec_depend>
 </package>

--- a/qt_gui_app/setup.py
+++ b/qt_gui_app/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup(

--- a/qt_gui_core/package.xml
+++ b/qt_gui_core/package.xml
@@ -1,4 +1,8 @@
-<package>
+<?xml version="1.0"?>
+<?xml-model
+  href="http://download.ros.org/schema/package_format3.xsd"
+  schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>qt_gui_core</name>
   <version>0.4.0</version>
   <description>
@@ -14,11 +18,11 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <run_depend version_gte="0.3.0">qt_dotgraph</run_depend>
-  <run_depend version_gte="0.3.0">qt_gui</run_depend>
-  <run_depend version_gte="0.3.0">qt_gui_app</run_depend>
-  <run_depend version_gte="0.3.0">qt_gui_cpp</run_depend>
-  <run_depend version_gte="0.3.0">qt_gui_py_common</run_depend>
+  <exec_depend version_gte="0.3.0">qt_dotgraph</exec_depend>
+  <exec_depend version_gte="0.3.0">qt_gui</exec_depend>
+  <exec_depend version_gte="0.3.0">qt_gui_app</exec_depend>
+  <exec_depend version_gte="0.3.0">qt_gui_cpp</exec_depend>
+  <exec_depend version_gte="0.3.0">qt_gui_py_common</exec_depend>
 
   <export>
     <metapackage/>

--- a/qt_gui_cpp/package.xml
+++ b/qt_gui_cpp/package.xml
@@ -1,4 +1,8 @@
-<package>
+<?xml version="1.0"?>
+<?xml-model
+  href="http://download.ros.org/schema/package_format3.xsd"
+  schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>qt_gui_cpp</name>
   <version>0.4.0</version>
   <description>

--- a/qt_gui_cpp/package.xml
+++ b/qt_gui_cpp/package.xml
@@ -14,6 +14,8 @@
   <author>Dirk Thomas</author>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
 
   <build_depend>cmake_modules</build_depend>
   <build_depend>pkg-config</build_depend>

--- a/qt_gui_cpp/package.xml
+++ b/qt_gui_cpp/package.xml
@@ -29,9 +29,9 @@
   <build_depend>qtbase5-dev</build_depend>
   <build_depend>tinyxml</build_depend>
 
-  <run_depend version_gte="1.9.23">pluginlib</run_depend>
-  <run_depend version_gte="0.3.0">qt_gui</run_depend>
-  <run_depend>tinyxml</run_depend>
+  <exec_depend version_gte="1.9.23">pluginlib</exec_depend>
+  <exec_depend version_gte="0.3.0">qt_gui</exec_depend>
+  <exec_depend>tinyxml</exec_depend>
 
   <export>
     <qt_gui plugin="${prefix}/plugin.xml"/>

--- a/qt_gui_cpp/setup.py
+++ b/qt_gui_cpp/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup(

--- a/qt_gui_py_common/package.xml
+++ b/qt_gui_py_common/package.xml
@@ -20,7 +20,7 @@
   <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
   <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
 
-  <exec_depend version_gte="0.3.0">python_qt_binding</exec_depend>
-  <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-rospkg</exec_depend>
-  <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-rospkg</exec_depend>
+  <run_depend version_gte="0.3.0">python_qt_binding</run_depend>
+  <run_depend condition="$ROS_PYTHON_VERSION == 2">python-rospkg</run_depend>
+  <run_depend condition="$ROS_PYTHON_VERSION == 3">python3-rospkg</run_depend>
 </package>

--- a/qt_gui_py_common/package.xml
+++ b/qt_gui_py_common/package.xml
@@ -20,7 +20,7 @@
   <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
   <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
 
-  <run_depend version_gte="0.3.0">python_qt_binding</run_depend>
-  <run_depend condition="$ROS_PYTHON_VERSION == 2">python-rospkg</run_depend>
-  <run_depend condition="$ROS_PYTHON_VERSION == 3">python3-rospkg</run_depend>
+  <exec_depend version_gte="0.3.0">python_qt_binding</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-rospkg</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-rospkg</exec_depend>
 </package>

--- a/qt_gui_py_common/package.xml
+++ b/qt_gui_py_common/package.xml
@@ -13,6 +13,8 @@
   <author>Dorian Scholz</author>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
 
   <exec_depend version_gte="0.3.0">python_qt_binding</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-rospkg</exec_depend>

--- a/qt_gui_py_common/package.xml
+++ b/qt_gui_py_common/package.xml
@@ -1,3 +1,7 @@
+<?xml version="1.0"?>
+<?xml-model
+  href="http://download.ros.org/schema/package_format3.xsd"
+  schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>qt_gui_py_common</name>
   <version>0.4.0</version>

--- a/qt_gui_py_common/setup.py
+++ b/qt_gui_py_common/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+from setuptools import setup
 
 from catkin_pkg.python_setup import generate_distutils_setup
 


### PR DESCRIPTION
This pull request is to apply the `noetic` migration by this ROS Wiki: http://wiki.ros.org/noetic/Migration

P.S. Updating it to `setuptools` helps packaging system such like `conda` packages passing `--single-version-externally-managed` to avoid Python `egg` generation.  