### PR TITLE
Quiet upstream Qt5 warnings

### DIFF
--- a/qt_gui_cpp/include/qt_gui_cpp/plugin_context.h
+++ b/qt_gui_cpp/include/qt_gui_cpp/plugin_context.h
@@ -39,7 +39,15 @@
 #include <QObject>
 #include <QString>
 #include <QStringList>
+// Upstream issue: https://codereview.qt-project.org/c/qt/qtbase/+/272258
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-copy"
+#endif
 #include <QVariant>
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
 #include <QWidget>
 
 namespace qt_gui_cpp

--- a/qt_gui_cpp/include/qt_gui_cpp/plugin_context.h
+++ b/qt_gui_cpp/include/qt_gui_cpp/plugin_context.h
@@ -40,12 +40,12 @@
 #include <QString>
 #include <QStringList>
 // Upstream issue: https://codereview.qt-project.org/c/qt/qtbase/+/272258
-#ifndef _WIN32
+#if __GNUC__ >= 9
 # pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Wdeprecated-copy"
 #endif
 #include <QVariant>
-#ifndef _WIN32
+#if __GNUC__ >= 9
 # pragma GCC diagnostic pop
 #endif
 #include <QWidget>

--- a/qt_gui_cpp/include/qt_gui_cpp/settings.h
+++ b/qt_gui_cpp/include/qt_gui_cpp/settings.h
@@ -37,7 +37,15 @@
 
 #include <QString>
 #include <QStringList>
+// Upstream issue: https://codereview.qt-project.org/c/qt/qtbase/+/272258
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-copy"
+#endif
 #include <QVariant>
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
 
 namespace qt_gui_cpp
 {

--- a/qt_gui_cpp/include/qt_gui_cpp/settings.h
+++ b/qt_gui_cpp/include/qt_gui_cpp/settings.h
@@ -38,12 +38,12 @@
 #include <QString>
 #include <QStringList>
 // Upstream issue: https://codereview.qt-project.org/c/qt/qtbase/+/272258
-#ifndef _WIN32
+#if __GNUC__ >= 9
 # pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Wdeprecated-copy"
 #endif
 #include <QVariant>
-#ifndef _WIN32
+#if __GNUC__ >= 9
 # pragma GCC diagnostic pop
 #endif
 


### PR DESCRIPTION
The warnings are produced by GCC 9 and Qt 5.12.5.
Once the referenced upstream issue has been resolved and patch released, we revert this change.

I'm not sure if we actually want to merge this change (for the sake of moving towards green builds) or wait for a fix upstream.