### PR TITLE
Catch runtime error on shutdown

### DIFF
--- a/qt_gui/src/qt_gui/dock_widget_title_bar.py
+++ b/qt_gui/src/qt_gui/dock_widget_title_bar.py
@@ -31,7 +31,7 @@
 import os
 
 from python_qt_binding import loadUi
-from python_qt_binding.QtCore import QEvent, QObject, Qt, qWarning
+from python_qt_binding.QtCore import qDebug, QEvent, QObject, Qt, qWarning
 from python_qt_binding.QtGui import QIcon
 from python_qt_binding.QtWidgets import QDockWidget, QMenu, QWidget
 
@@ -104,9 +104,6 @@ class DockWidgetTitleBar(QWidget):
             self.minimize_button.hide()
             self.float_button.hide()
             self.close_button.hide()
-
-    def __del__(self):
-        self._dock_widget.removeEventFilter(self)
 
     def connect_button(self, button_id, callback):
         button = self._extra_buttons.get(button_id, None)

--- a/qt_gui/src/qt_gui/dock_widget_title_bar.py
+++ b/qt_gui/src/qt_gui/dock_widget_title_bar.py
@@ -31,7 +31,7 @@
 import os
 
 from python_qt_binding import loadUi
-from python_qt_binding.QtCore import qDebug, QEvent, QObject, Qt, qWarning
+from python_qt_binding.QtCore import QEvent, QObject, Qt, qWarning
 from python_qt_binding.QtGui import QIcon
 from python_qt_binding.QtWidgets import QDockWidget, QMenu, QWidget
 


### PR DESCRIPTION
Re-opening #211 

> without this fix, we get this error on shutdown:

```
Exception ignored in: <bound method DockWidgetTitleBar.__del__ of <qt_gui.dock_widget_title_bar.DockWidgetTitleBar object at 0x7f149e805b88>>
Traceback (most recent call last):
  File "/home/mike/ws_ros2/install/qt_gui/lib/python3.6/site-packages/qt_gui/dock_widget_title_bar.py", line 109, in __del__
    self._dock_widget.removeEventFilter(self)
RuntimeError: wrapped C/C++ object of type DockWidget has been deleted
```

> From the documentation, "[All event filters for this object are automatically removed when this object is destroyed](https://doc.qt.io/qt-5/qobject.html#removeEventFilter)". Thus calling removeEventFilter is not necessary which is why we get a run time exception trying to remove event filters for a deleted object


