### PR TITLE
fix CMake warning about using uninitialized variables

### DIFF
--- a/qt_gui_py_common/CMakeLists.txt
+++ b/qt_gui_py_common/CMakeLists.txt
@@ -10,10 +10,6 @@ ament_python_install_package(${PROJECT_NAME}
 install(DIRECTORY resource
   DESTINATION share/${PROJECT_NAME})
 
-install(TARGETS ${_library_name}
-  DESTINATION "${PYTHON_INSTALL_DIR}/${PROJECT_NAME}"
-)
-
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
 


### PR DESCRIPTION
When invoking CMake with `--warn-uninitialized`.