### PR TITLE
Fix broken get_settings() in ExclusiveOptionGroup

### DIFF
--- a/qt_gui_py_common/src/qt_gui_py_common/exclusive_options_group.py
+++ b/qt_gui_py_common/src/qt_gui_py_common/exclusive_options_group.py
@@ -68,8 +68,7 @@ class ExclusiveOptionGroup(QGroupBox):
         """Return dictionary with selected_index (int) and selected_option (dict) keys."""
         selected_index = self._button_group.checkedId()
         if selected_index >= 0:
-            return
-            {
+            return {
                 'selected_index': selected_index,
                 'selected_option': self._options[selected_index]
             }


### PR DESCRIPTION
Currently it returns the `None` object if the selected index was valid, which of course breaks the functionality. Looks like the bug was introduced in a023298 while making some formatting changes.

Found this bug while trying to change the Plot Type in `rqt_plot`.