### PR TITLE
Use ament_target_dependencies for qt_gui_cpp.

### DIFF
--- a/qt_gui_cpp/CMakeLists.txt
+++ b/qt_gui_cpp/CMakeLists.txt
@@ -16,6 +16,7 @@ endif()
 
 find_package(pluginlib REQUIRED)
 find_package(tinyxml2_vendor REQUIRED)
+find_package(TinyXML2 REQUIRED)
 
 ament_python_install_package(${PROJECT_NAME}
   PACKAGE_DIR src/${PROJECT_NAME})

--- a/qt_gui_cpp/CMakeLists.txt
+++ b/qt_gui_cpp/CMakeLists.txt
@@ -20,8 +20,6 @@ find_package(tinyxml2_vendor REQUIRED)
 ament_python_install_package(${PROJECT_NAME}
   PACKAGE_DIR src/${PROJECT_NAME})
 
-include_directories(include ${TinyXML2_INCLUDE_DIRS} ${pluginlib_INCLUDE_DIRS})
-
 add_subdirectory(src)
 
 install(FILES plugin.xml

--- a/qt_gui_cpp/src/qt_gui_cpp/CMakeLists.txt
+++ b/qt_gui_cpp/src/qt_gui_cpp/CMakeLists.txt
@@ -35,8 +35,11 @@ set(qt_gui_cpp_LINK_LIBRARIES
 qt5_wrap_cpp(qt_gui_cpp_MOCS ${qt_gui_cpp_HDRS})
 
 ament_export_dependencies(pluginlib TinyXML2)
-include_directories(${PROJECT_NAME} ${qt_gui_cpp_INCLUDE_DIRECTORIES})
 add_library(${PROJECT_NAME} ${qt_gui_cpp_SRCS} ${qt_gui_cpp_MOCS})
+target_include_directories(${PROJECT_NAME} PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include>")
+target_include_directories(${PROJECT_NAME} PRIVATE ${qt_gui_cpp_INCLUDE_DIRECTORIES})
 ament_target_dependencies(${PROJECT_NAME} pluginlib TinyXML2)
 
 if (WIN32)
@@ -46,7 +49,7 @@ if (WIN32)
   target_compile_options(${PROJECT_NAME} PUBLIC "/Zc:__cplusplus")
 endif()
 
-target_link_libraries(${PROJECT_NAME} ${qt_gui_cpp_LINK_LIBRARIES} ${ament_LIBRARIES} Qt5::Widgets)
+target_link_libraries(${PROJECT_NAME} ${qt_gui_cpp_LINK_LIBRARIES} Qt5::Widgets)
 
 install(TARGETS ${PROJECT_NAME}
   ARCHIVE DESTINATION lib

--- a/qt_gui_cpp/src/qt_gui_cpp/CMakeLists.txt
+++ b/qt_gui_cpp/src/qt_gui_cpp/CMakeLists.txt
@@ -34,9 +34,10 @@ set(qt_gui_cpp_LINK_LIBRARIES
 
 qt5_wrap_cpp(qt_gui_cpp_MOCS ${qt_gui_cpp_HDRS})
 
-ament_export_dependencies(pluginlib)
-include_directories(${PROJECT_NAME} ${qt_gui_cpp_INCLUDE_DIRECTORIES} ${pluginlib_INCLUDE_DIRS})
+ament_export_dependencies(pluginlib TinyXML2)
+include_directories(${PROJECT_NAME} ${qt_gui_cpp_INCLUDE_DIRECTORIES})
 add_library(${PROJECT_NAME} ${qt_gui_cpp_SRCS} ${qt_gui_cpp_MOCS})
+ament_target_dependencies(${PROJECT_NAME} pluginlib TinyXML2)
 
 if (WIN32)
   # On Windows systems, Visual Studio does not currently set __cplusplus correctly unless this
@@ -45,7 +46,7 @@ if (WIN32)
   target_compile_options(${PROJECT_NAME} PUBLIC "/Zc:__cplusplus")
 endif()
 
-target_link_libraries(${PROJECT_NAME} ${qt_gui_cpp_LINK_LIBRARIES} ${ament_LIBRARIES} Qt5::Widgets ${TinyXML2_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${qt_gui_cpp_LINK_LIBRARIES} ${ament_LIBRARIES} Qt5::Widgets)
 
 install(TARGETS ${PROJECT_NAME}
   ARCHIVE DESTINATION lib

--- a/qt_gui_cpp/src/qt_gui_cpp_shiboken/CMakeLists.txt
+++ b/qt_gui_cpp/src/qt_gui_cpp_shiboken/CMakeLists.txt
@@ -55,14 +55,13 @@ if(shiboken_helper_FOUND)
 
     shiboken_include_directories(qt_gui_cpp_shiboken "${qt_gui_cpp_shiboken_QT_COMPONENTS}")
 
-    add_library(qt_gui_cpp_shiboken ${qt_gui_cpp_shiboken_SRCS})
+    add_library(qt_gui_cpp_shiboken SHARED ${qt_gui_cpp_shiboken_SRCS})
     target_include_directories(qt_gui_cpp_shiboken PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../include)
     target_link_libraries(qt_gui_cpp_shiboken ${PROJECT_NAME})
     ament_target_dependencies(qt_gui_cpp_shiboken pluginlib TinyXML2)
     shiboken_target_link_libraries(qt_gui_cpp_shiboken "${qt_gui_cpp_shiboken_QT_COMPONENTS}")
 
     install(TARGETS qt_gui_cpp_shiboken
-      ARCHIVE DESTINATION lib
-      LIBRARY DESTINATION lib)
+      DESTINATION ${PYTHON_INSTALL_DIR}/${PROJECT_NAME})
   endif()
 endif()

--- a/qt_gui_cpp/src/qt_gui_cpp_shiboken/CMakeLists.txt
+++ b/qt_gui_cpp/src/qt_gui_cpp_shiboken/CMakeLists.txt
@@ -51,8 +51,7 @@ if(shiboken_helper_FOUND)
     set(qt_gui_cpp_BINDINGS "${qt_gui_cpp_BINDINGS}" PARENT_SCOPE)
 
     set(QT_INCLUDE_DIR "${Qt5Widgets_INCLUDE_DIRS}")
-    string(REPLACE ";" ":" qt_gui_cpp_INCLUDE_PATH_WITH_COLONS "${qt_gui_cpp_INCLUDE_PATH}")
-    shiboken_generator(libqt_gui_cpp global.h typesystem.xml ${PROJECT_SOURCE_DIR}/src/qt_gui_cpp_shiboken "${qt_gui_cpp_shiboken_SRCS}" "${qt_gui_cpp_HDRS}" "${qt_gui_cpp_INCLUDE_PATH_WITH_COLONS}" "${CMAKE_CURRENT_BINARY_DIR}")
+    shiboken_generator(libqt_gui_cpp global.h typesystem.xml ${PROJECT_SOURCE_DIR}/src/qt_gui_cpp_shiboken "${qt_gui_cpp_shiboken_SRCS}" "${qt_gui_cpp_HDRS}" "${qt_gui_cpp_INCLUDE_PATH}" "${CMAKE_CURRENT_BINARY_DIR}")
 
     shiboken_include_directories(qt_gui_cpp_shiboken "${qt_gui_cpp_shiboken_QT_COMPONENTS}")
 

--- a/qt_gui_cpp/src/qt_gui_cpp_shiboken/CMakeLists.txt
+++ b/qt_gui_cpp/src/qt_gui_cpp_shiboken/CMakeLists.txt
@@ -36,6 +36,8 @@ set(qt_gui_cpp_HDRS
   ${qt_gui_cpp_INCLUDE_PATH}/qt_gui_cpp/ros_pluginlib_plugin_provider_for_plugins.h
   ${qt_gui_cpp_INCLUDE_PATH}/qt_gui_cpp/settings.h
 )
+ament_get_recursive_properties(deps_include_dirs _ ${TinyXML2_TARGETS} ${pluginlib_TARGETS})
+list(APPEND qt_gui_cpp_INCLUDE_PATH ${deps_include_dirs})
 
 find_package(python_qt_binding REQUIRED)
 include(${python_qt_binding_DIR}/shiboken_helper.cmake)
@@ -49,13 +51,15 @@ if(shiboken_helper_FOUND)
     set(qt_gui_cpp_BINDINGS "${qt_gui_cpp_BINDINGS}" PARENT_SCOPE)
 
     set(QT_INCLUDE_DIR "${Qt5Widgets_INCLUDE_DIRS}")
-    shiboken_generator(libqt_gui_cpp global.h typesystem.xml ${PROJECT_SOURCE_DIR}/src/qt_gui_cpp_shiboken "${qt_gui_cpp_shiboken_SRCS}" "${qt_gui_cpp_HDRS}" "${qt_gui_cpp_INCLUDE_PATH}" "${CMAKE_CURRENT_BINARY_DIR}")
+    string(REPLACE ";" ":" qt_gui_cpp_INCLUDE_PATH_WITH_COLONS "${qt_gui_cpp_INCLUDE_PATH}")
+    shiboken_generator(libqt_gui_cpp global.h typesystem.xml ${PROJECT_SOURCE_DIR}/src/qt_gui_cpp_shiboken "${qt_gui_cpp_shiboken_SRCS}" "${qt_gui_cpp_HDRS}" "${qt_gui_cpp_INCLUDE_PATH_WITH_COLONS}" "${CMAKE_CURRENT_BINARY_DIR}")
 
-    include_directories(qt_gui_cpp_shiboken ${qt_gui_cpp_INCLUDE_PATH}/qt_gui_cpp)
     shiboken_include_directories(qt_gui_cpp_shiboken "${qt_gui_cpp_shiboken_QT_COMPONENTS}")
 
     add_library(qt_gui_cpp_shiboken ${qt_gui_cpp_shiboken_SRCS})
-    target_link_libraries(qt_gui_cpp_shiboken ${PROJECT_NAME} ${ament_LIBRARIES})
+    target_include_directories(qt_gui_cpp_shiboken PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../include)
+    target_link_libraries(qt_gui_cpp_shiboken ${PROJECT_NAME})
+    ament_target_dependencies(qt_gui_cpp_shiboken pluginlib TinyXML2)
     shiboken_target_link_libraries(qt_gui_cpp_shiboken "${qt_gui_cpp_shiboken_QT_COMPONENTS}")
 
     install(TARGETS qt_gui_cpp_shiboken

--- a/qt_gui_cpp/src/qt_gui_cpp_sip/CMakeLists.txt
+++ b/qt_gui_cpp/src/qt_gui_cpp_sip/CMakeLists.txt
@@ -31,8 +31,9 @@ set(qt_gui_cpp_sip_INCLUDE_DIRS ${qt_gui_cpp_INCLUDE_DIRS} "${CMAKE_CURRENT_SOUR
 set(qt_gui_cpp_sip_LIBRARY_DIRS ${qt_gui_cpp_LIBRARY_DIRS} lib)
 set(qt_gui_cpp_sip_LDFLAGS_OTHER ${qt_gui_cpp_LDFLAGS_OTHER})
 
+ament_get_recursive_properties(deps_include_dirs _ ${pluginlib_TARGETS})
+
 set(_qt_gui_cpp_sip_LIBRARIES
-  ${pluginlib_LIBRARIES}
   ${PYTHON_LIBRARY}
   qt_gui_cpp
 )
@@ -48,16 +49,14 @@ foreach(_lib_name ${_qt_gui_cpp_sip_LIBRARIES})
   endif()
 endforeach()
 
-set(qt_gui_cpp_INCLUDE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../include ${pluginlib_INCLUDE_DIRS})
-
 find_package(python_qt_binding REQUIRED)
 include(${python_qt_binding_DIR}/sip_helper.cmake)
 
 ament_export_dependencies(pluginlib)
-include_directories(${PROJECT_NAME} ${qt_gui_cpp_INCLUDE_DIRECTORIES} ${pluginlib_INCLUDE_DIRS})
+include_directories(${PROJECT_NAME} ${qt_gui_cpp_INCLUDE_DIRECTORIES} ${deps_include_dirs})
 
 # The include directories used by build_sip_binding are different than the one set in include directories
-set(qt_gui_cpp_sip_INCLUDE_DIRS ${qt_gui_cpp_sip_INCLUDE_DIRS} ${pluginlib_INCLUDE_DIRS})
+set(qt_gui_cpp_sip_INCLUDE_DIRS ${qt_gui_cpp_sip_INCLUDE_DIRS} ${deps_include_dirs})
 
 if(sip_helper_FOUND)
   list(APPEND qt_gui_cpp_BINDINGS "sip")

--- a/qt_gui_cpp/src/qt_gui_cpp_sip/CMakeLists.txt
+++ b/qt_gui_cpp/src/qt_gui_cpp_sip/CMakeLists.txt
@@ -31,9 +31,10 @@ set(qt_gui_cpp_sip_INCLUDE_DIRS ${qt_gui_cpp_INCLUDE_DIRS} "${CMAKE_CURRENT_SOUR
 set(qt_gui_cpp_sip_LIBRARY_DIRS ${qt_gui_cpp_LIBRARY_DIRS} lib)
 set(qt_gui_cpp_sip_LDFLAGS_OTHER ${qt_gui_cpp_LDFLAGS_OTHER})
 
-ament_get_recursive_properties(deps_include_dirs _ ${pluginlib_TARGETS})
+ament_get_recursive_properties(deps_include_dirs deps_libraries ${pluginlib_TARGETS})
 
 set(_qt_gui_cpp_sip_LIBRARIES
+  ${deps_libraries}
   ${PYTHON_LIBRARY}
   qt_gui_cpp
 )

--- a/qt_gui_cpp/src/qt_gui_cpp_sip/CMakeLists.txt
+++ b/qt_gui_cpp/src/qt_gui_cpp_sip/CMakeLists.txt
@@ -32,6 +32,8 @@ set(qt_gui_cpp_sip_LIBRARY_DIRS ${qt_gui_cpp_LIBRARY_DIRS} lib)
 set(qt_gui_cpp_sip_LDFLAGS_OTHER ${qt_gui_cpp_LDFLAGS_OTHER})
 
 ament_get_recursive_properties(deps_include_dirs deps_libraries ${pluginlib_TARGETS})
+list(APPEND deps_include_dirs ${TinyXML2_INCLUDE_DIRS})
+list(APPEND deps_libraries ${TinyXML2_LIBRARIES})
 
 set(_qt_gui_cpp_sip_LIBRARIES
   ${deps_libraries}


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Needs https://github.com/ros2/console_bridge_vendor/pull/9 to work properly.  Still a WIP, as we can't build qt_gui_sip with this in place.