### PR TITLE
fix shebang line for python3

### DIFF
--- a/qt_gui_app/CMakeLists.txt
+++ b/qt_gui_app/CMakeLists.txt
@@ -6,6 +6,6 @@ catkin_package()
 
 catkin_python_setup()
 
-install(PROGRAMS scripts/qt_gui_app
+catkin_install_python(PROGRAMS scripts/qt_gui_app
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )


### PR DESCRIPTION
Similar to https://github.com/ros-visualization/rqt_graph/pull/43

Without this change the script cannot be rosrun on Noetic/Focal and results in:
`/usr/bin/env: ‘python’: No such file or directory`

Python scripts need to be installed using `catkin_install_python` for the shebang line to be rewritten to point to python3. More details at https://wiki.ros.org/UsingPython3/SourceCodeChanges#Changing_shebangs

Signed-off-by: Mikael Arguedas <mikael.arguedas@gmail.com>