### PR TITLE
Removed tango-icon-theme dependency

### DIFF
--- a/qt_gui/package.xml
+++ b/qt_gui/package.xml
@@ -22,7 +22,6 @@
   <exec_depend>ament_index_python</exec_depend>
   <exec_depend>python_qt_binding</exec_depend>
   <exec_depend>python3-catkin-pkg-modules</exec_depend>
-  <exec_depend>tango-icon-theme</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/qt_gui/src/qt_gui/main.py
+++ b/qt_gui/src/qt_gui/main.py
@@ -34,7 +34,6 @@ from __future__ import print_function
 
 from argparse import ArgumentParser, SUPPRESS
 import os
-import platform
 import signal
 import sys
 

--- a/qt_gui/src/qt_gui/main.py
+++ b/qt_gui/src/qt_gui/main.py
@@ -191,21 +191,6 @@ class Main(object):
     def _add_reload_paths(self, reload_importer):
         reload_importer.add_reload_path(os.path.join(os.path.dirname(__file__), *('..',) * 4))
 
-    def _check_icon_theme_compliance(self):
-        from python_qt_binding.QtGui import QIcon
-        # TODO find a better way to verify Theme standard compliance
-        if QIcon.fromTheme('document-save').isNull() or \
-           QIcon.fromTheme('document-open').isNull() or \
-           QIcon.fromTheme('edit-cut').isNull() or \
-           QIcon.fromTheme('object-flip-horizontal').isNull():
-            if platform.system() == 'Darwin' and \
-                    '/usr/local/share/icons' not in QIcon.themeSearchPaths():
-                QIcon.setThemeSearchPaths(QIcon.themeSearchPaths() + ['/usr/local/share/icons'])
-            original_theme = QIcon.themeName()
-            QIcon.setThemeName('Tango')
-            if QIcon.fromTheme('document-save').isNull():
-                QIcon.setThemeName(original_theme)
-
     def create_application(self, argv):
         from python_qt_binding.QtCore import Qt
         from python_qt_binding.QtWidgets import QApplication
@@ -444,8 +429,6 @@ class Main(object):
             qInstallMessageHandler(message_handler)
 
         app = self.create_application(argv)
-
-        self._check_icon_theme_compliance()
 
         settings = QSettings(
             QSettings.IniFormat, QSettings.UserScope, 'ros.org', self._settings_filename)


### PR DESCRIPTION
As discussed in this PR https://github.com/ros-visualization/tango_icons_vendor/pull/4#pullrequestreview-424674382 we are going to remove the `tango-icon-theme` dependency and replace it with the [tango_icons_vendor](https://github.com/ros-visualization/tango_icons_vendor/) package.

The logic and the new dependency will be updated in this other PR https://github.com/ros-visualization/qt_gui_core/pull/222

Signed-off-by: ahcorde <ahcorde@gmail.com>