### PR TITLE
qt_gui_cpp_sip: declare private assignment operator for SIP

### DIFF
--- a/qt_gui_cpp/src/qt_gui_cpp_sip/plugin_context.sip
+++ b/qt_gui_cpp/src/qt_gui_cpp_sip/plugin_context.sip
@@ -25,6 +25,10 @@ public:
 
   void reloadPlugin();
 
+private:
+
+  PluginContext& operator=(const PluginContext&);
+
 };
 
 };


### PR DESCRIPTION
Required for SIP v4.19.23 or newer (e.g. on macOS with HomeBrew).

Same issue as for [python_orocos_kdl](https://github.com/orocos/orocos_kinematics_dynamics), which was fixed by @jspricke in https://github.com/orocos/orocos_kinematics_dynamics/pull/270:

> Starting with v4.19.23 SIP expects a working operator= or one marked
> private explicitly. All classes in this PR have a reference member
> (&chain) resulting in the compiler deleting the default assignment
> operator. This PR makes this known to SIP as well.