### PR TITLE
Fix exporting perspective for Python 3.6

### DIFF
--- a/qt_gui/src/qt_gui/perspective_manager.py
+++ b/qt_gui/src/qt_gui/perspective_manager.py
@@ -443,11 +443,11 @@ class PerspectiveManager(QObject):
             for i in range(1, value.size(), 2):
                 try:
                     character = value.at(i)
+                    if isinstance(character, bytes):
+                        character = character.decode('utf-8')
                     # output all non-control characters
-                    character_encoded = character.encode('utf-8') if type(character) == str else character
-                    character_decoded = character if type(character) == str else character.decode('utf-8')
-                    if character_encoded >= b' ' and character_encoded <= b'~':
-                        characters += character_decoded
+                    if character >= ' ' and character <= '~':
+                        characters += character
                     else:
                         characters += ' '
                 except UnicodeDecodeError:

--- a/qt_gui/src/qt_gui/perspective_manager.py
+++ b/qt_gui/src/qt_gui/perspective_manager.py
@@ -444,8 +444,10 @@ class PerspectiveManager(QObject):
                 try:
                     character = value.at(i)
                     # output all non-control characters
-                    if character >= b' ' and character <= b'~':
-                        characters += character.decode('utf-8')
+                    character_encoded = character.encode('utf-8') if type(character) == str else character
+                    character_decoded = character if type(character) == str else character.decode('utf-8')
+                    if character_encoded >= b' ' and character_encoded <= b'~':
+                        characters += character_decoded
                     else:
                         characters += ' '
                 except UnicodeDecodeError:


### PR DESCRIPTION
For me, #216 is still present with Python 3.6. I think the fix in #217 only solved the problem for Python 3.8. For me with Python 3.6, the variable `character` is a string and not `bytes`, which is why I added a type check to catch this.