### PR TITLE
[backport noetic] Quiet upstream Qt5 warnings

### DIFF
--- a/qt_gui_cpp/include/qt_gui_cpp/plugin_context.h
+++ b/qt_gui_cpp/include/qt_gui_cpp/plugin_context.h
@@ -40,7 +40,15 @@
 #include <QObject>
 #include <QString>
 #include <QStringList>
+// Upstream issue: https://codereview.qt-project.org/c/qt/qtbase/+/272258
+#if __GNUC__ >= 9
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-copy"
+#endif
 #include <QVariant>
+#if __GNUC__ >= 9
+# pragma GCC diagnostic pop
+#endif
 #include <QWidget>
 
 namespace qt_gui_cpp

--- a/qt_gui_cpp/include/qt_gui_cpp/settings.h
+++ b/qt_gui_cpp/include/qt_gui_cpp/settings.h
@@ -37,7 +37,15 @@
 
 #include <QString>
 #include <QStringList>
+// Upstream issue: https://codereview.qt-project.org/c/qt/qtbase/+/272258
+#if __GNUC__ >= 9
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-copy"
+#endif
 #include <QVariant>
+#if __GNUC__ >= 9
+# pragma GCC diagnostic pop
+#endif
 
 namespace qt_gui_cpp
 {


### PR DESCRIPTION
Backport of #210 to suppress the compiler warning seen in the Noetic `dev` and PR jobs: [![Build Status](http://build.ros.org/buildStatus/icon?job=Ndev__qt_gui_core__ubuntu_focal_amd64&build=10)](http://build.ros.org/job/Ndev__qt_gui_core__ubuntu_focal_amd64/10/)