### PR TITLE
avoid a warning about C++ plugins on Windows

### DIFF
--- a/qt_gui_cpp/CMakeLists.txt
+++ b/qt_gui_cpp/CMakeLists.txt
@@ -11,6 +11,10 @@ find_package(ament_cmake REQUIRED)
 if(WIN32)
   message(STATUS "${PROJECT_NAME} is not yet supported on Windows. Package will not be built.")
   ament_package()
+  file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/plugin.xml"
+    "<library path=\"src\"/>")
+  install(FILES "${CMAKE_CURRENT_BINARY_DIR}/plugin.xml"
+    DESTINATION share/${PROJECT_NAME})
   return()
 endif()
 


### PR DESCRIPTION
Resolves the first four warnings reported in ros2/ros2_documentation#808.