### PR TITLE
ugly hack to avoid 'cannot allocate memory in static TLS block' when loading shared libs

### DIFF
--- a/qt_gui/src/qt_gui/main.py
+++ b/qt_gui/src/qt_gui/main.py
@@ -406,6 +406,14 @@ class Main(object):
                 return 0
             raise RuntimeError('Unknown command not handled')
 
+        try:
+            # HACK importing cv2 before any Qt modules prevents shared objects
+            # like rqt_image_view on Ubuntu Focal to fail loading with the
+            # error message 'cannot allocate memory in static TLS block'
+            import cv2  # noqa: F401
+        except ImportError:
+            pass
+
         # choose selected or default qt binding
         setattr(sys, 'SELECT_QT_BINDING', self._options.qt_binding)
         from python_qt_binding import QT_BINDING


### PR DESCRIPTION
Fixes ros-visualization/rqt_image_view#38.