### PR TITLE
Switch to using the filesystem implementation in rcpputils.

### DIFF
--- a/qt_gui_cpp/CMakeLists.txt
+++ b/qt_gui_cpp/CMakeLists.txt
@@ -19,6 +19,7 @@ if(WIN32)
 endif()
 
 find_package(pluginlib REQUIRED)
+find_package(rcpputils REQUIRED)
 find_package(tinyxml2_vendor REQUIRED)
 find_package(TinyXML2 REQUIRED)
 
@@ -35,7 +36,7 @@ install(
   DESTINATION include
 )
 
-ament_export_dependencies(pluginlib)
+ament_export_dependencies(pluginlib rcpputils)
 ament_export_include_directories(include)
 
 ament_export_include_directories(include)

--- a/qt_gui_cpp/include/qt_gui_cpp/ros_pluginlib_plugin_provider.h
+++ b/qt_gui_cpp/include/qt_gui_cpp/ros_pluginlib_plugin_provider.h
@@ -44,7 +44,7 @@
 #include "plugin_provider.h"
 
 #include <pluginlib/class_loader.hpp>
-#include <pluginlib/impl/filesystem_helper.hpp>
+#include <rcpputils/filesystem_helper.hpp>
 #include <tinyxml2.h>
 
 #include <QCoreApplication>
@@ -145,7 +145,7 @@ public:
 
       std::string name = class_loader_->getName(lookup_name);
       std::string plugin_xml = class_loader_->getPluginManifestPath(lookup_name);
-      pluginlib::impl::fs::path p(plugin_xml);
+      rcpputils::fs::path p(plugin_xml);
       std::string plugin_path = p.parent_path().string();
 
       QMap<QString, QString> attributes;

--- a/qt_gui_cpp/package.xml
+++ b/qt_gui_cpp/package.xml
@@ -20,14 +20,16 @@
   <build_depend version_gte="0.3.0">python_qt_binding</build_depend>
   <build_depend>qt5-qmake</build_depend>
   <build_depend>qtbase5-dev</build_depend>
+  <build_depend>rcpputils</build_depend>
   <build_depend>tinyxml2_vendor</build_depend>
 
   <exec_depend version_gte="1.9.23">pluginlib</exec_depend>
   <exec_depend version_gte="0.3.0">qt_gui</exec_depend>
+  <exec_depend>rcpputils</exec_depend>
   <exec_depend>tinyxml2_vendor</exec_depend>
 
   <test_depend>ament_cmake_pytest</test_depend>
-  
+
   <export>
     <build_type>ament_cmake</build_type>
     <qt_gui plugin="${prefix}/plugin.xml"/>

--- a/qt_gui_cpp/src/qt_gui_cpp/CMakeLists.txt
+++ b/qt_gui_cpp/src/qt_gui_cpp/CMakeLists.txt
@@ -34,13 +34,13 @@ set(qt_gui_cpp_LINK_LIBRARIES
 
 qt5_wrap_cpp(qt_gui_cpp_MOCS ${qt_gui_cpp_HDRS})
 
-ament_export_dependencies(pluginlib TinyXML2)
+ament_export_dependencies(pluginlib rcpputils TinyXML2)
 add_library(${PROJECT_NAME} ${qt_gui_cpp_SRCS} ${qt_gui_cpp_MOCS})
 target_include_directories(${PROJECT_NAME} PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>"
   "$<INSTALL_INTERFACE:include>")
 target_include_directories(${PROJECT_NAME} PRIVATE ${qt_gui_cpp_INCLUDE_DIRECTORIES})
-ament_target_dependencies(${PROJECT_NAME} pluginlib TinyXML2)
+ament_target_dependencies(${PROJECT_NAME} pluginlib rcpputils TinyXML2)
 
 if (WIN32)
   # On Windows systems, Visual Studio does not currently set __cplusplus correctly unless this


### PR DESCRIPTION
That implementation is more complete and better tested.  This
also gets us closer to remove the pluginlib implementation
of the filesystem helper.

Note that this doesn't really change the dependencies of this
package; this package already recursively depended on rcpputils,
now it just directly depends on it.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>