### PR TITLE
Fix deprecated QMap to QMultiMap

### DIFF
--- a/qt_gui_cpp/src/qt_gui_cpp/plugin_provider.cpp
+++ b/qt_gui_cpp/src/qt_gui_cpp/plugin_provider.cpp
@@ -42,7 +42,7 @@ PluginProvider::~PluginProvider()
 
 QMap<QString, QString> PluginProvider::discover(QObject* discovery_data)
 {
-  QMap<QString, QString> plugins;
+  QMultiMap<QString, QString> plugins;
   QList<PluginDescriptor*> descriptors = discover_descriptors(discovery_data);
   for (QList<PluginDescriptor*>::iterator it = descriptors.begin(); it != descriptors.end(); it++)
   {


### PR DESCRIPTION
‘QMap<K, V>& QMap<K, V>::unite(const QMap<K, V>&) [with Key = QString; T = QString]’ is deprecated. Replace it with QMultiMap.