### PR TITLE
[Melodic] Fix 'dict_keys' object not subscriptable

### DIFF
--- a/qt_gui/src/qt_gui/plugin_manager_dbus_interface.py
+++ b/qt_gui/src/qt_gui/plugin_manager_dbus_interface.py
@@ -56,6 +56,6 @@ class PluginManagerDBusInterface(Object):
                   'matching "%s"\n%s' % (plugin_name, '\n'.join(plugins.values()))
             qWarning(msg)
             return (1, msg)
-        plugin_id = plugins.keys()[0]
+        plugin_id = next(iter(plugins))
         self._plugin_manager.load_plugin(plugin_id, argv=argv.split(' ') if argv else [])
         return (0, plugin_id)


### PR DESCRIPTION
dict_keys() is not indexable in Python 3.

Port of #243 for Melodic. 

Signed-off-by: Michael Jeronimo <michael.jeronimo@openrobotics.org>