### PR TITLE
Fix failure to build by using rcpputils instead of pluginlib impl

### DIFF
--- a/qt_gui_cpp/CMakeLists.txt
+++ b/qt_gui_cpp/CMakeLists.txt
@@ -19,6 +19,7 @@ if(WIN32)
 endif()
 
 find_package(pluginlib REQUIRED)
+find_package(rcpputils REQUIRED)
 find_package(tinyxml2_vendor REQUIRED)
 find_package(TinyXML2 REQUIRED)
 
@@ -36,6 +37,7 @@ install(
 )
 
 ament_export_dependencies(pluginlib)
+ament_export_dependencies(rcpputils)
 ament_export_include_directories(include)
 
 ament_export_include_directories(include)

--- a/qt_gui_cpp/include/qt_gui_cpp/ros_pluginlib_plugin_provider.h
+++ b/qt_gui_cpp/include/qt_gui_cpp/ros_pluginlib_plugin_provider.h
@@ -44,7 +44,7 @@
 #include "plugin_provider.h"
 
 #include <pluginlib/class_loader.hpp>
-#include <pluginlib/impl/filesystem_helper.hpp>
+#include <rcpputils/filesystem_helper.hpp>
 #include <tinyxml2.h>
 
 #include <QCoreApplication>
@@ -145,7 +145,7 @@ public:
 
       std::string name = class_loader_->getName(lookup_name);
       std::string plugin_xml = class_loader_->getPluginManifestPath(lookup_name);
-      pluginlib::impl::fs::path p(plugin_xml);
+      rcpputils::fs::path p(plugin_xml);
       std::string plugin_path = p.parent_path().string();
 
       QMap<QString, QString> attributes;

--- a/qt_gui_cpp/package.xml
+++ b/qt_gui_cpp/package.xml
@@ -15,6 +15,8 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>rcpputils</depend>
+
   <build_depend>pkg-config</build_depend>
   <build_depend version_gte="1.9.23">pluginlib</build_depend>
   <build_depend version_gte="0.3.0">python_qt_binding</build_depend>


### PR DESCRIPTION
Fixes failure to build caused by pluginlib's implementation changing:
https://github.com/ros/pluginlib/pull/212

Note for reviewer: this fix is also required to build on my machine https://github.com/ament/ament_cmake/pull/318

Signed-off-by: Shane Loretz <sloretz@openrobotics.org>
Signed-off-by: Shane Loretz <sloretz@osrfoundation.org>