### PR TITLE
Always prefer 'Tango' icon theme

### DIFF
--- a/qt_gui/src/qt_gui/main.py
+++ b/qt_gui/src/qt_gui/main.py
@@ -34,7 +34,6 @@ from __future__ import print_function
 
 from argparse import ArgumentParser, SUPPRESS
 import os
-import platform
 import signal
 import sys
 

--- a/qt_gui/src/qt_gui/main.py
+++ b/qt_gui/src/qt_gui/main.py
@@ -193,20 +193,19 @@ class Main(object):
 
     def _set_theme_if_necessary(self):
         from python_qt_binding.QtGui import QIcon
-        # if themeName is defined we are on Linux
-        # otherwise try to use the them provided by tango_icons_vendor
-        if not QIcon.themeName():
-            package_path = has_resource('packages', 'tango_icons_vendor')
-            if package_path:
-                icon_paths = QIcon.themeSearchPaths()
-                icon_paths.append(os.path.join(
-                    package_path, 'share', 'tango_icons_vendor',
-                    'resource', 'icons', 'Tango'))
-                QIcon.setThemeSearchPaths(icon_paths)
-                QIcon.setThemeName('scalable')
-            elif platform.system() != 'Linux':
-                print("The 'tango_icons_vendor' package was not found - icons "
-                      'will not work', file=sys.stderr)
+        # Always prefer tango_icons_vendor
+        package_path = has_resource('packages', 'tango_icons_vendor')
+        if package_path:
+            icon_paths = QIcon.themeSearchPaths()
+            icon_paths = [
+                os.path.join(package_path, 'share', 'tango_icons_vendor', 'resource', 'icons')
+            ] + icon_paths
+            QIcon.setThemeSearchPaths(icon_paths)
+        # Use Tango if possible, fall back to system default
+        original_theme = QIcon.themeName()
+        QIcon.setThemeName('Tango')
+        if QIcon.fromTheme('document-save').isNull():
+            QIcon.setThemeName(original_theme)
 
     def create_application(self, argv):
         from python_qt_binding.QtCore import Qt


### PR DESCRIPTION
The legacy behavior was to attmpt to detect if an existing theme was already set which supplied some of the needed icons, and if not, use the Tango theme specifically. If that didn't work either, revert the change to the original theme (or lack thereof).

The current behavior changes the theme only if no theme is set, and only if tango_icons_vendor is installed. This breaks down on Ubuntu Focal because the default theme (hicolor) doesn't supply the necessary icons for rqt to function properly. On Fedora, the default theme (Adwaita) appeared to work properly.

This change makes qt_gui always prefer the 'Tango' theme, and always prefer the version supplied by tango_icons_vendor (if available). If 'Tango' is not available, fall back to the system theme (or lack thereof).

Related to #222, #224, and ros-visualization/tango_icons_vendor#8
Fixes ros-visualization/rqt#249