### PR TITLE
Install headers to include/${PROJECT_NAME}

### DIFF
--- a/qt_gui_cpp/CMakeLists.txt
+++ b/qt_gui_cpp/CMakeLists.txt
@@ -49,7 +49,7 @@ qt5_wrap_cpp(qt_gui_cpp_MOCS ${qt_gui_cpp_HDRS})
 add_library(${PROJECT_NAME} SHARED ${qt_gui_cpp_SRCS} ${qt_gui_cpp_MOCS})
 target_include_directories(${PROJECT_NAME} PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>"
-  "$<INSTALL_INTERFACE:include>")
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
 
 target_link_libraries(${PROJECT_NAME}
   ${QT_QTCORE_LIBRARY}
@@ -72,7 +72,7 @@ install(FILES plugin.xml
 
 install(
   DIRECTORY include/
-  DESTINATION include
+  DESTINATION include/${PROJECT_NAME}
 )
 
 ament_export_dependencies(pluginlib rcpputils TinyXML2)


### PR DESCRIPTION
Part of ros2/ros2#1150 - this installs includes to another project name folder to avoid include directory search order issues when overriding this package.