### PR TITLE
Enable basic help information if no plugins are running

### DIFF
--- a/qt_gui/src/qt_gui/main.py
+++ b/qt_gui/src/qt_gui/main.py
@@ -512,6 +512,7 @@ class Main(object):
         if main_window is not None:
             container_manager = ContainerManager(main_window, plugin_manager)
             plugin_manager.set_main_window(main_window, menu_bar, container_manager)
+            plugin_manager.plugin_load_unload_signal.connect(main_window.plugins_changed)
 
             if not self._options.freeze_layout:
                 minimized_dock_widgets_toolbar = MinimizedDockWidgetsToolbar(

--- a/qt_gui/src/qt_gui/main.py
+++ b/qt_gui/src/qt_gui/main.py
@@ -214,7 +214,7 @@ class Main(object):
         return app
 
     def main(self, argv=None, standalone=None, plugin_argument_provider=None,
-             plugin_manager_settings_prefix=''):
+             plugin_manager_settings_prefix='', help_text=None):
         if argv is None:
             argv = sys.argv
 
@@ -452,7 +452,7 @@ class Main(object):
             if self._options.clear_config:
                 settings.clear()
 
-            main_window = MainWindow()
+            main_window = MainWindow(help_text)
             if self._options.on_top:
                 main_window.setWindowFlags(Qt.WindowStaysOnTopHint)
 
@@ -512,7 +512,7 @@ class Main(object):
         if main_window is not None:
             container_manager = ContainerManager(main_window, plugin_manager)
             plugin_manager.set_main_window(main_window, menu_bar, container_manager)
-            plugin_manager.plugin_load_unload_signal.connect(main_window.plugins_changed)
+            plugin_manager.plugin_load_unload_signal.connect(main_window.showHelpWidget)
 
             if not self._options.freeze_layout:
                 minimized_dock_widgets_toolbar = MinimizedDockWidgetsToolbar(

--- a/qt_gui/src/qt_gui/main_window.py
+++ b/qt_gui/src/qt_gui/main_window.py
@@ -56,6 +56,7 @@ class MainWindow(DockableMainWindow):
             self._help_widget.setTextInteractionFlags(Qt.TextBrowserInteraction)
             self._help_widget.setOpenExternalLinks(True)
             self._help_widget.setHtml(help_text)
+            self._help_widget.setStyleSheet("background:transparent;")
 
         self._save_on_close_signaled = False
         self._global_settings = None

--- a/qt_gui/src/qt_gui/main_window.py
+++ b/qt_gui/src/qt_gui/main_window.py
@@ -28,8 +28,9 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from python_qt_binding.QtCore import qDebug, Qt, Signal
-from python_qt_binding.QtWidgets import QToolBar
+from python_qt_binding.QtCore import qDebug, Qt, Signal, QRect
+from python_qt_binding.QtWidgets import QToolBar, QTextBrowser
+from python_qt_binding.QtGui import QFont
 
 from qt_gui.dockable_main_window import DockableMainWindow
 from qt_gui.settings import Settings
@@ -44,10 +45,38 @@ class MainWindow(DockableMainWindow):
         super(MainWindow, self).__init__()
         self.setObjectName('MainWindow')
 
+        font = QFont()
+        font.setPointSize(14)
+
+        self._info = QTextBrowser(self)
+        self._info.setFont(font)
+        self._info.setReadOnly(True)
+        self._info.setTextInteractionFlags(Qt.TextBrowserInteraction)
+        self._info.setOpenExternalLinks(True)
+        self._info.setHtml(
+            """<p><b>rqt</b> is a GUI framework that is able to load various plug-in tools as dockable windows.
+There are currently no plug-ins selected. To add plug-ins, select items from the <b>Plugins</b> menu.</p>
+<p>You may also save a particular arrangement of plug-ins as a <i>perspective</i> using the <b>Perspectives</b> menu.
+<p>See <a href="http://wiki.ros.org/rqt/">the rqt Wiki page</a> for more information</p>
+""")
+
         self._save_on_close_signaled = False
         self._global_settings = None
         self._perspective_settings = None
         self._settings = None
+
+    def plugins_changed(self, num_plugins):
+        self._info.hide() if num_plugins else self._info.show()
+
+    def resizeEvent(self, event):
+        size = self.size()
+        info_percentage = 0.75
+        margin_percentage = (1.0 - info_percentage) / 2
+        self._info.setGeometry(
+            QRect(size.width() * margin_percentage,
+                  size.height() * margin_percentage,
+                  size.width() * info_percentage,
+                  size.height() * info_percentage))
 
     def closeEvent(self, event):
         qDebug('MainWindow.closeEvent()')

--- a/qt_gui/src/qt_gui/main_window.py
+++ b/qt_gui/src/qt_gui/main_window.py
@@ -72,10 +72,10 @@ class MainWindow(DockableMainWindow):
         margin_percentage = (1.0 - info_percentage) / 2
         if self._help_widget:
             self._help_widget.setGeometry(
-                QRect(size.width() * margin_percentage,
-                      size.height() * margin_percentage,
-                      size.width() * info_percentage,
-                      size.height() * info_percentage))
+                QRect(int(size.width() * margin_percentage),
+                      int(size.height() * margin_percentage),
+                      int(size.width() * info_percentage),
+                      int(size.height() * info_percentage)))
 
     def closeEvent(self, event):
         qDebug('MainWindow.closeEvent()')

--- a/qt_gui/src/qt_gui/main_window.py
+++ b/qt_gui/src/qt_gui/main_window.py
@@ -41,42 +41,41 @@ class MainWindow(DockableMainWindow):
 
     save_settings_before_close_signal = Signal(Settings, Settings)
 
-    def __init__(self):
+    def __init__(self, help_text=None):
         super(MainWindow, self).__init__()
         self.setObjectName('MainWindow')
+        self._help_widget = None
 
-        font = QFont()
-        font.setPointSize(14)
+        if help_text:
+            font = QFont()
+            font.setPointSize(14)
 
-        self._info = QTextBrowser(self)
-        self._info.setFont(font)
-        self._info.setReadOnly(True)
-        self._info.setTextInteractionFlags(Qt.TextBrowserInteraction)
-        self._info.setOpenExternalLinks(True)
-        self._info.setHtml(
-            """<p><b>rqt</b> is a GUI framework that is able to load various plug-in tools as dockable windows.
-There are currently no plug-ins selected. To add plug-ins, select items from the <b>Plugins</b> menu.</p>
-<p>You may also save a particular arrangement of plug-ins as a <i>perspective</i> using the <b>Perspectives</b> menu.
-<p>See <a href="http://wiki.ros.org/rqt/">the rqt Wiki page</a> for more information</p>
-""")
+            self._help_widget = QTextBrowser(self)
+            self._help_widget.setFont(font)
+            self._help_widget.setReadOnly(True)
+            self._help_widget.setTextInteractionFlags(Qt.TextBrowserInteraction)
+            self._help_widget.setOpenExternalLinks(True)
+            self._help_widget.setHtml(help_text)
 
         self._save_on_close_signaled = False
         self._global_settings = None
         self._perspective_settings = None
         self._settings = None
 
-    def plugins_changed(self, num_plugins):
-        self._info.hide() if num_plugins else self._info.show()
+    def showHelpWidget(self, should_show):
+        if self._help_widget:
+            self._help_widget.show() if should_show else self._help_widget.hide()
 
     def resizeEvent(self, event):
         size = self.size()
         info_percentage = 0.75
         margin_percentage = (1.0 - info_percentage) / 2
-        self._info.setGeometry(
-            QRect(size.width() * margin_percentage,
-                  size.height() * margin_percentage,
-                  size.width() * info_percentage,
-                  size.height() * info_percentage))
+        if self._help_widget:
+            self._help_widget.setGeometry(
+                QRect(size.width() * margin_percentage,
+                      size.height() * margin_percentage,
+                      size.width() * info_percentage,
+                      size.height() * info_percentage))
 
     def closeEvent(self, event):
         qDebug('MainWindow.closeEvent()')

--- a/qt_gui/src/qt_gui/main_window.py
+++ b/qt_gui/src/qt_gui/main_window.py
@@ -68,10 +68,10 @@ class MainWindow(DockableMainWindow):
             self._help_widget.show() if should_show else self._help_widget.hide()
 
     def resizeEvent(self, event):
-        size = self.size()
-        info_percentage = 0.75
-        margin_percentage = (1.0 - info_percentage) / 2
         if self._help_widget:
+            size = self.size()
+            info_percentage = 0.75
+            margin_percentage = (1.0 - info_percentage) / 2
             self._help_widget.setGeometry(
                 QRect(int(size.width() * margin_percentage),
                       int(size.height() * margin_percentage),

--- a/qt_gui/src/qt_gui/plugin_manager.py
+++ b/qt_gui/src/qt_gui/plugin_manager.py
@@ -293,7 +293,7 @@ class PluginManager(QObject):
         handler.close_signal.connect(self.unload_plugin)
         handler.reload_signal.connect(self.reload_plugin)
         handler.help_signal.connect(self._emit_plugin_help_signal)
-        self.plugin_load_unload_signal.emit(len(self._running_plugins))
+        self.plugin_load_unload_signal.emit(len(self._running_plugins) == 0)
 
     def _emit_plugin_help_signal(self, instance_id_str):
         instance_id = PluginInstanceId(instance_id=instance_id_str)
@@ -368,7 +368,7 @@ class PluginManager(QObject):
     def _unload_plugin_completed(self, instance_id):
         qDebug('PluginManager._unload_plugin_completed(%s)' % str(instance_id))
         self._remove_running_plugin(instance_id)
-        self.plugin_load_unload_signal.emit(len(self._running_plugins))
+        self.plugin_load_unload_signal.emit(len(self._running_plugins) == 0)
 
     def _remove_running_plugin(self, instance_id):
         info = self._running_plugins[str(instance_id)]

--- a/qt_gui/src/qt_gui/plugin_manager.py
+++ b/qt_gui/src/qt_gui/plugin_manager.py
@@ -51,6 +51,7 @@ class PluginManager(QObject):
     specific set of running plugins.
     """
 
+    plugin_load_unload_signal = Signal(int)
     plugins_about_to_change_signal = Signal()
     plugins_changed_signal = Signal()
     plugin_help_signal = Signal(object)
@@ -292,6 +293,7 @@ class PluginManager(QObject):
         handler.close_signal.connect(self.unload_plugin)
         handler.reload_signal.connect(self.reload_plugin)
         handler.help_signal.connect(self._emit_plugin_help_signal)
+        self.plugin_load_unload_signal.emit(len(self._running_plugins))
 
     def _emit_plugin_help_signal(self, instance_id_str):
         instance_id = PluginInstanceId(instance_id=instance_id_str)
@@ -366,6 +368,7 @@ class PluginManager(QObject):
     def _unload_plugin_completed(self, instance_id):
         qDebug('PluginManager._unload_plugin_completed(%s)' % str(instance_id))
         self._remove_running_plugin(instance_id)
+        self.plugin_load_unload_signal.emit(len(self._running_plugins))
 
     def _remove_running_plugin(self, instance_id):
         info = self._running_plugins[str(instance_id)]


### PR DESCRIPTION
If there are no plug-ins loaded, enable the display of an optional help widget on the main window that can display basic usage information.

Fixes: ros-visualization/rqt#267

Signed-off-by: Michael Jeronimo <michael.jeronimo@openrobotics.org>