### PR TITLE
Cast drawLine input arguments to int

### DIFF
--- a/qt_dotgraph/src/qt_dotgraph/dot_shapes.py
+++ b/qt_dotgraph/src/qt_dotgraph/dot_shapes.py
@@ -42,4 +42,5 @@ class QGraphicsBox3dItem(QAbstractGraphicsShapeItem):
         painter.drawLine((int)(self._bounding_box.topRight().x()),
                          (int)(self._bounding_box.topRight().y()),
                          (int)(self._bounding_box.topRight().x()),
-                         (int)(self._bounding_box.bottomRight().y() - self._bounding_box.height() * 0.1))
+                         ((int)(self._bounding_box.bottomRight().y()
+                                - self._bounding_box.height() * 0.1)))

--- a/qt_dotgraph/src/qt_dotgraph/dot_shapes.py
+++ b/qt_dotgraph/src/qt_dotgraph/dot_shapes.py
@@ -19,28 +19,28 @@ class QGraphicsBox3dItem(QAbstractGraphicsShapeItem):
                            self._bounding_box.height() - self._bounding_box.height() * 0.1)
         painter.drawRect(rectangle)
         # Top line
-        painter.drawLine((int)(rectangle.topLeft().x() + self._bounding_box.height() * 0.1),
-                         (int)(self._bounding_box.topLeft().y()),
-                         (int)(self._bounding_box.topRight().x()),
-                         (int)(self._bounding_box.topRight().y()))
+        painter.drawLine(int(rectangle.topLeft().x() + self._bounding_box.height() * 0.1),
+                         int(self._bounding_box.topLeft().y()),
+                         int(self._bounding_box.topRight().x()),
+                         int(self._bounding_box.topRight().y()))
         # Top left corner
-        painter.drawLine((int)(rectangle.topLeft().x() + self._bounding_box.height() * 0.1),
-                         (int)(self._bounding_box.topLeft().y()),
-                         (int)(self._bounding_box.topLeft().x() + 1),
-                         (int)(rectangle.topLeft().y()))
+        painter.drawLine(int(rectangle.topLeft().x() + self._bounding_box.height() * 0.1),
+                         int(self._bounding_box.topLeft().y()),
+                         int(self._bounding_box.topLeft().x() + 1),
+                         int(rectangle.topLeft().y()))
         # Top right corner
-        painter.drawLine((int)(self._bounding_box.topRight().x()),
-                         (int)(self._bounding_box.topRight().y()),
-                         (int)(rectangle.topRight().x()),
-                         (int)(rectangle.topRight().y()))
+        painter.drawLine(int(self._bounding_box.topRight().x()),
+                         int(self._bounding_box.topRight().y()),
+                         int(rectangle.topRight().x()),
+                         int(rectangle.topRight().y()))
         # Bottom right corner
-        painter.drawLine((int)(rectangle.bottomRight().x() + 1),
-                         (int)(rectangle.bottomRight().y() - 1),
-                         (int)(self._bounding_box.bottomRight().x()),
-                         (int)(rectangle.bottomRight().y() - self._bounding_box.height() * 0.1))
+        painter.drawLine(int(rectangle.bottomRight().x() + 1),
+                         int(rectangle.bottomRight().y() - 1),
+                         int(self._bounding_box.bottomRight().x()),
+                         int(rectangle.bottomRight().y() - self._bounding_box.height() * 0.1))
         # Right line
-        painter.drawLine((int)(self._bounding_box.topRight().x()),
-                         (int)(self._bounding_box.topRight().y()),
-                         (int)(self._bounding_box.topRight().x()),
-                         ((int)(self._bounding_box.bottomRight().y()
-                                - self._bounding_box.height() * 0.1)))
+        painter.drawLine(int(self._bounding_box.topRight().x()),
+                         int(self._bounding_box.topRight().y()),
+                         int(self._bounding_box.topRight().x()),
+                         int(self._bounding_box.bottomRight().y()
+                             - self._bounding_box.height() * 0.1))

--- a/qt_dotgraph/src/qt_dotgraph/dot_shapes.py
+++ b/qt_dotgraph/src/qt_dotgraph/dot_shapes.py
@@ -13,33 +13,33 @@ class QGraphicsBox3dItem(QAbstractGraphicsShapeItem):
 
     def paint(self, painter, option, widget):
         # Main rectangle
-        rectangle = QRectF(self._bounding_box.topLeft().x(),
+        rectangle = QRectF((int)(self._bounding_box.topLeft().x()),
                            self._bounding_box.topLeft().y() + self._bounding_box.height() * 0.1,
                            self._bounding_box.width() - self._bounding_box.height() * 0.1,
                            self._bounding_box.height() - self._bounding_box.height() * 0.1)
         painter.drawRect(rectangle)
         # Top line
-        painter.drawLine(rectangle.topLeft().x() + self._bounding_box.height() * 0.1,
-                         self._bounding_box.topLeft().y(),
-                         self._bounding_box.topRight().x(),
-                         self._bounding_box.topRight().y())
+        painter.drawLine((int)(rectangle.topLeft().x() + self._bounding_box.height() * 0.1),
+                         (int)(self._bounding_box.topLeft().y()),
+                         (int)(self._bounding_box.topRight().x()),
+                         (int)(self._bounding_box.topRight().y()))
         # Top left corner
-        painter.drawLine(rectangle.topLeft().x() + self._bounding_box.height() * 0.1,
-                         self._bounding_box.topLeft().y(),
-                         self._bounding_box.topLeft().x() + 1,
-                         rectangle.topLeft().y())
+        painter.drawLine((int)(rectangle.topLeft().x() + self._bounding_box.height() * 0.1),
+                         (int)(self._bounding_box.topLeft().y()),
+                         (int)(self._bounding_box.topLeft().x() + 1),
+                         (int)(rectangle.topLeft().y()))
         # Top right corner
-        painter.drawLine(self._bounding_box.topRight().x(),
-                         self._bounding_box.topRight().y(),
-                         rectangle.topRight().x(),
-                         rectangle.topRight().y())
+        painter.drawLine((int)(self._bounding_box.topRight().x()),
+                         (int)(self._bounding_box.topRight().y()),
+                         (int)(rectangle.topRight().x()),
+                         (int)(rectangle.topRight().y()))
         # Bottom right corner
-        painter.drawLine(rectangle.bottomRight().x() + 1,
-                         rectangle.bottomRight().y() - 1,
-                         self._bounding_box.bottomRight().x(),
-                         rectangle.bottomRight().y() - self._bounding_box.height() * 0.1)
+        painter.drawLine((int)(rectangle.bottomRight().x() + 1),
+                         (int)(rectangle.bottomRight().y() - 1),
+                         (int)(self._bounding_box.bottomRight().x()),
+                         (int)(rectangle.bottomRight().y() - self._bounding_box.height() * 0.1))
         # Right line
-        painter.drawLine(self._bounding_box.topRight().x(),
-                         self._bounding_box.topRight().y(),
-                         self._bounding_box.topRight().x(),
-                         self._bounding_box.bottomRight().y() - self._bounding_box.height() * 0.1)
+        painter.drawLine((int)(self._bounding_box.topRight().x()),
+                         (int)(self._bounding_box.topRight().y()),
+                         (int)(self._bounding_box.topRight().x()),
+                         (int)(self._bounding_box.bottomRight().y() - self._bounding_box.height() * 0.1))

--- a/qt_dotgraph/src/qt_dotgraph/dot_shapes.py
+++ b/qt_dotgraph/src/qt_dotgraph/dot_shapes.py
@@ -13,7 +13,7 @@ class QGraphicsBox3dItem(QAbstractGraphicsShapeItem):
 
     def paint(self, painter, option, widget):
         # Main rectangle
-        rectangle = QRectF((int)(self._bounding_box.topLeft().x()),
+        rectangle = QRectF(self._bounding_box.topLeft().x(),
                            self._bounding_box.topLeft().y() + self._bounding_box.height() * 0.1,
                            self._bounding_box.width() - self._bounding_box.height() * 0.1,
                            self._bounding_box.height() - self._bounding_box.height() * 0.1)


### PR DESCRIPTION
I was getting the following error and resulting crash when using `rqt_graph` on humble with python 3.10.

```bash
Traceback (most recent call last):
  File "/home/ros/install/qt_dotgraph/local/lib/python3.10/dist-packages/qt_dotgraph/dot_shapes.py", line 16, in paint
    rectangle = QRect(self._bounding_box.topLeft().x(),
TypeError: arguments did not match any overloaded call:
  QRect(): too many arguments
  QRect(int, int, int, int): argument 1 has unexpected type 'float'
  QRect(QPoint, QPoint): argument 1 has unexpected type 'float'
  QRect(QPoint, QSize): argument 1 has unexpected type 'float'
  QRect(QRect): argument 1 has unexpected type 'float'
Aborted (core dumped)
```

Explicitly casting the inputs to int seems to resolve this issue.