### PR TITLE
Fix shiboken error

### DIFF
--- a/qt_gui_cpp/src/qt_gui_cpp_shiboken/typesystem.xml
+++ b/qt_gui_cpp/src/qt_gui_cpp_shiboken/typesystem.xml
@@ -13,8 +13,12 @@
     <object-type name="PluginProvider"/>
     <object-type name="RecursivePluginProvider"/>
     <object-type name="RosPluginlibPluginProvider" generate="no"/>
-    <object-type name="RosPluginlibPluginProvider_ForPluginProviders"/>
-    <object-type name="RosPluginlibPluginProvider_ForPlugins"/>
+    <object-type name="RosPluginlibPluginProvider_ForPluginProviders">
+    <add-function signature="shutdown" return-type="void" access="public" static="no"/>
+    </object-type>
+    <object-type name="RosPluginlibPluginProvider_ForPlugins">
+    <add-function signature="shutdown" return-type="void" access="public" static="no"/>
+    </object-type>
     <object-type name="Settings"/>
   </namespace-type>
 </typesystem>


### PR DESCRIPTION
When running rqt with PySide2 it does not shutdown cleanly.
```
PluginHandler.shutdown_plugin() plugin "rqt_topic/TopicPlugin#1" raised an exception:
Traceback (most recent call last):
  File "/opt/ros/humble/local/lib/python3.10/dist-packages/qt_gui/plugin_handler.py", line 136, in shutdown_plugin
    self._shutdown_plugin()
  File "/opt/ros/humble/local/lib/python3.10/dist-packages/qt_gui/plugin_handler_direct.py", line 92, in _shutdown_plugin
    self.emit_shutdown_plugin_completed()
  File "/opt/ros/humble/local/lib/python3.10/dist-packages/qt_gui/plugin_handler.py", line 150, in emit_shutdown_plugin_completed
    callback(self._instance_id)
  File "/opt/ros/humble/local/lib/python3.10/dist-packages/qt_gui/plugin_manager.py", line 480, in _close_application_shutdown_callback
    self._close_application_signal()
  File "/opt/ros/humble/local/lib/python3.10/dist-packages/qt_gui/plugin_manager.py", line 483, in _close_application_signal
    self._plugin_provider.shutdown()
  File "/opt/ros/humble/local/lib/python3.10/dist-packages/qt_gui/composite_plugin_provider.py", line 87, in shutdown
    plugin_provider.shutdown()
  File "/opt/ros/humble/local/lib/python3.10/dist-packages/qt_gui/composite_plugin_provider.py", line 87, in shutdown
    plugin_provider.shutdown()
  File "/opt/ros/humble/local/lib/python3.10/dist-packages/qt_gui/composite_plugin_provider.py", line 87, in shutdown
    plugin_provider.shutdown()
  File "/home/christoph/ws_ros2/install/qt_gui_cpp/local/lib/python3.10/dist-packages/qt_gui_cpp/ros_pluginlib_plugin_provider.py", line 95, in shutdown
    self._plugin_provider.shutdown()
AttributeError: 'libqt_gui_cpp_shiboken.qt_gui_cpp.RosPluginlibPlug' object has no attribute 'shutdown
```

Shiboken2 does not generate or optimizes the shutdown function away. This fix adds it manually - it is an empty function anyway.
