### PR TITLE
Remove sip dependencies for macOS

### DIFF
--- a/qt_gui_cpp/CMakeLists.txt
+++ b/qt_gui_cpp/CMakeLists.txt
@@ -19,7 +19,7 @@ if(WIN32)
 endif()
 
 find_package(pluginlib REQUIRED)
-find_package(Qt5 REQUIRED COMPONENTS Widgets)
+find_package(Qt5 REQUIRED COMPONENTS Core Gui Widgets)
 find_package(rcpputils REQUIRED)
 find_package(tinyxml2_vendor REQUIRED)
 find_package(TinyXML2 REQUIRED)
@@ -60,7 +60,9 @@ target_link_libraries(${PROJECT_NAME}
   tinyxml2::tinyxml2)
 
 add_subdirectory(src/qt_gui_cpp_shiboken)
-add_subdirectory(src/qt_gui_cpp_sip)
+if (NOT APPLE)
+  add_subdirectory(src/qt_gui_cpp_sip)
+endif()
 
 message(STATUS "Python binding generators: ${qt_gui_cpp_BINDINGS}")
 if(NOT qt_gui_cpp_BINDINGS)

--- a/qt_gui_cpp/CMakeLists.txt
+++ b/qt_gui_cpp/CMakeLists.txt
@@ -18,6 +18,15 @@ if(WIN32)
   return()
 endif()
 
+# FindPythonLibs deprecated since 3.12
+# https://cmake.org/cmake/help/latest/module/FindPythonLibs.html
+# Use FindPython to set the cache variables.
+find_package(Python 3 REQUIRED
+  COMPONENTS Interpreter Development
+)
+set(PYTHON_LIBRARY ${Python_LIBRARY_DIRS})
+set(PYTHON_INCLUDE_DIR ${Python_INCLUDE_DIRS})
+
 find_package(pluginlib REQUIRED)
 find_package(Qt5 REQUIRED COMPONENTS Core Gui Widgets)
 find_package(rcpputils REQUIRED)

--- a/qt_gui_cpp/src/CMakeLists.txt
+++ b/qt_gui_cpp/src/CMakeLists.txt
@@ -3,7 +3,9 @@ add_subdirectory(qt_gui_cpp)
 set(qt_gui_cpp_BINDINGS "")
 
 add_subdirectory(qt_gui_cpp_shiboken)
-add_subdirectory(qt_gui_cpp_sip)
+if (NOT APPLE)
+  add_subdirectory(qt_gui_cpp_sip)
+endif()
 
 message(STATUS "Python binding generators: ${qt_gui_cpp_BINDINGS}")
 if(NOT qt_gui_cpp_BINDINGS)

--- a/qt_gui_cpp/src/qt_gui_cpp_shiboken/CMakeLists.txt
+++ b/qt_gui_cpp/src/qt_gui_cpp_shiboken/CMakeLists.txt
@@ -50,6 +50,15 @@ if(shiboken_helper_FOUND)
     list(APPEND qt_gui_cpp_BINDINGS "shiboken")
     set(qt_gui_cpp_BINDINGS "${qt_gui_cpp_BINDINGS}" PARENT_SCOPE)
 
+    if (APPLE)
+      # The shiboken_generator fails without these includes.
+      # TODO: resolve why these cannot be set using the component variables
+      #       Qt5Core_INCLUDE_DIRS etc.
+      list(APPEND qt_gui_cpp_INCLUDE_PATH "${Qt5_DIR}/../../../include")
+      list(APPEND qt_gui_cpp_INCLUDE_PATH "${Qt5_DIR}/../../../include/QtCore")
+      list(APPEND qt_gui_cpp_INCLUDE_PATH "${Qt5_DIR}/../../../include/QtWidgets")
+    endif()
+
     set(QT_INCLUDE_DIR "${Qt5Widgets_INCLUDE_DIRS}")
     shiboken_generator(libqt_gui_cpp global.h typesystem.xml ${PROJECT_SOURCE_DIR}/src/qt_gui_cpp_shiboken "${qt_gui_cpp_shiboken_SRCS}" "${qt_gui_cpp_HDRS}" "${qt_gui_cpp_INCLUDE_PATH}" "${CMAKE_CURRENT_BINARY_DIR}")
 
@@ -57,9 +66,20 @@ if(shiboken_helper_FOUND)
 
     add_library(qt_gui_cpp_shiboken SHARED ${qt_gui_cpp_shiboken_SRCS})
     target_include_directories(qt_gui_cpp_shiboken PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../include)
-    target_link_libraries(qt_gui_cpp_shiboken ${PROJECT_NAME})
+    target_link_libraries(qt_gui_cpp_shiboken
+      ${PROJECT_NAME}
+      Qt5::Core
+      Qt5::Gui
+      Qt5::Widgets
+    )
     ament_target_dependencies(qt_gui_cpp_shiboken pluginlib TinyXML2)
     shiboken_target_link_libraries(qt_gui_cpp_shiboken "${qt_gui_cpp_shiboken_QT_COMPONENTS}")
+
+    if (APPLE)
+      # the brew installed version of cmake (>3.24) supports Python3_SOABI
+      find_package(Python3 COMPONENTS Development)
+      set_target_properties(qt_gui_cpp_shiboken PROPERTIES SUFFIX ".${Python3_SOABI}.so")
+    endif()
 
     install(TARGETS qt_gui_cpp_shiboken
       DESTINATION ${PYTHON_INSTALL_DIR}/${PROJECT_NAME})


### PR DESCRIPTION
This PR removes the dependency on `qt_gui_cpp_sip` when running macOS.

Partial fix for https://github.com/ros-visualization/python_qt_binding/issues/103. See also https://github.com/ros-visualization/python_qt_binding/pull/118 which is a pre-requisite for this change.

Qt bindings for macOS are available using PySide2. The brew formula for `pyside@2` is keg only, to build and run using PySide2 set the environment variables:

```zsh
export CMAKE_PREFIX_PATH=/usr/local/opt/pyside@2:$CMAKE_PREFIX_PATH
export PATH=/usr/local/opt/pyside@2/bin:$PATH
export PYTHONPATH=$PYTHONPATH:/usr/local/opt/pyside@2/lib/python3.10/site-packages
```

The changes to `qt_gui_cpp_shiboken` address include path resolution issues that caused the build to fail. The modification for the `qt_gui_cpp_INCLUDE_PATH` is not very satisfactory. Using the component properties `Qt5Core_INCLUDE_DIRS` etc. which would be preferable does not seem to work.