### PR TITLE
Compile error fix

### DIFF
--- a/qt_gui_cpp/src/qt_gui_cpp_sip/CMakeLists.txt
+++ b/qt_gui_cpp/src/qt_gui_cpp_sip/CMakeLists.txt
@@ -35,7 +35,8 @@ ament_get_recursive_properties(deps_include_dirs deps_libraries ${pluginlib_TARG
 list(APPEND deps_include_dirs ${TinyXML2_INCLUDE_DIRS})
 list(APPEND deps_libraries ${TinyXML2_LIBRARIES})
 
-find_package(Python3 REQUIRED COMPONENTS Development)
+# Find python before pybind11
+find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
 
 set(_qt_gui_cpp_sip_LIBRARIES
   ${deps_libraries}


### PR DESCRIPTION
Fix compile error.
 

--- stderr: qt_gui_cpp                                                                                                                                             CMake Error at /usr/share/cmake-3.25/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
  Could NOT find Python3 (missing: Development Development.Module
  Development.Embed) (found version "3.11")
Call Stack (most recent call first):
  /usr/share/cmake-3.25/Modules/FindPackageHandleStandardArgs.cmake:600 (_FPHSA_FAILURE_MESSAGE)
  /usr/share/cmake-3.25/Modules/FindPython/Support.cmake:3240 (find_package_handle_standard_args)
  /usr/share/cmake-3.25/Modules/FindPython3.cmake:490 (include)
  src/qt_gui_cpp_sip/CMakeLists.txt:38 (find_package)