### PR TITLE
(qt_gui) setFallbackThemeName(original_theme)

### DIFF
--- a/qt_gui/src/qt_gui/main.py
+++ b/qt_gui/src/qt_gui/main.py
@@ -200,11 +200,21 @@ class Main(object):
                 os.path.join(package_path, 'share', 'tango_icons_vendor', 'resource', 'icons')
             ] + icon_paths
             QIcon.setThemeSearchPaths(icon_paths)
+
         # Use Tango if possible, fall back to system default
         original_theme = QIcon.themeName()
+        if original_theme == 'Tango':
+            # We don't have any back-up behaviour in case Tango is the default
+            return
+        # Set Tango as default and try to get an icon
         QIcon.setThemeName('Tango')
         if QIcon.fromTheme('document-save').isNull():
+            # When Tango icon can't be found, use the system default theme
             QIcon.setThemeName(original_theme)
+            return
+        # In case we overruled the default theme to be Tango, set fallback theme to the original
+        # theme. Any original fallback theme is dropped in this case.
+        QIcon.setFallbackThemeName(original_theme)
 
     def create_application(self, argv):
         from python_qt_binding.QtCore import Qt


### PR DESCRIPTION
Old:
![old](https://github.com/ros-visualization/qt_gui_core/assets/18014833/eafc7a63-9a3e-4cb4-9f8a-0e78f216712c)

New:
![new](https://github.com/ros-visualization/qt_gui_core/assets/18014833/fb881d7b-1b2c-4cd0-86ce-6737909b74b7)

Iron backport: https://github.com/ros-visualization/qt_gui_core/pull/281
Humble backport: https://github.com/ros-visualization/qt_gui_core/pull/280

Fixes: https://github.com/ros-visualization/rqt_image_view/issues/79
