### PR TITLE
Switch from rcpputils::fs to std::filesystem

### DIFF
--- a/qt_gui_cpp/CMakeLists.txt
+++ b/qt_gui_cpp/CMakeLists.txt
@@ -21,7 +21,6 @@ endif()
 
 find_package(pluginlib REQUIRED)
 find_package(Qt5 REQUIRED COMPONENTS Widgets)
-find_package(rcpputils REQUIRED)
 find_package(tinyxml2_vendor REQUIRED)
 find_package(TinyXML2 REQUIRED)
 
@@ -57,7 +56,6 @@ target_link_libraries(${PROJECT_NAME}
   ${QT_QTGUI_LIBRARY}
   Qt5::Widgets
   pluginlib::pluginlib
-  rcpputils::rcpputils
   tinyxml2::tinyxml2)
 
 add_subdirectory(src/qt_gui_cpp_shiboken)
@@ -76,7 +74,7 @@ install(
   DESTINATION include/${PROJECT_NAME}
 )
 
-ament_export_dependencies(pluginlib rcpputils TinyXML2)
+ament_export_dependencies(pluginlib TinyXML2)
 ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
 
 install(TARGETS ${PROJECT_NAME}

--- a/qt_gui_cpp/include/qt_gui_cpp/ros_pluginlib_plugin_provider.h
+++ b/qt_gui_cpp/include/qt_gui_cpp/ros_pluginlib_plugin_provider.h
@@ -44,7 +44,6 @@
 #include "plugin_provider.h"
 
 #include <pluginlib/class_loader.hpp>
-#include <rcpputils/filesystem_helper.hpp>
 #include <tinyxml2.h>
 
 #include <QCoreApplication>
@@ -54,6 +53,7 @@
 #include <QObject>
 #include <QString>
 
+#include <filesystem>
 #include <fstream>
 #include <string>
 #include <vector>
@@ -145,7 +145,7 @@ public:
 
       std::string name = class_loader_->getName(lookup_name);
       std::string plugin_xml = class_loader_->getPluginManifestPath(lookup_name);
-      rcpputils::fs::path p(plugin_xml);
+      std::filesystem::path p(plugin_xml);
       std::string plugin_path = p.parent_path().string();
 
       QMap<QString, QString> attributes;

--- a/qt_gui_cpp/package.xml
+++ b/qt_gui_cpp/package.xml
@@ -20,12 +20,10 @@
   <build_depend version_gte="0.3.0">python_qt_binding</build_depend>
   <build_depend>qt5-qmake</build_depend>
   <build_depend>qtbase5-dev</build_depend>
-  <build_depend>rcpputils</build_depend>
   <build_depend>tinyxml2_vendor</build_depend>
 
   <exec_depend version_gte="1.9.23">pluginlib</exec_depend>
   <exec_depend version_gte="0.3.0">qt_gui</exec_depend>
-  <exec_depend>rcpputils</exec_depend>
   <exec_depend>tinyxml2_vendor</exec_depend>
 
   <test_depend>ament_cmake_pytest</test_depend>


### PR DESCRIPTION
Requires https://github.com/ros-visualization/python_qt_binding/pull/135

Part of https://github.com/ros2/rcpputils/issues/164

Relates to https://github.com/ros/pluginlib/pull/254

Since we were only using `rcpputils` for `rcpputils::fs`, remove the dependency completely. Note that we need https://github.com/ros-visualization/python_qt_binding/pull/135 to build the bindings with C++17.