### PR TITLE
Small fix for modern flake8.

### DIFF
--- a/qt_dotgraph/src/qt_dotgraph/pydotfactory.py
+++ b/qt_dotgraph/src/qt_dotgraph/pydotfactory.py
@@ -176,7 +176,7 @@ class PydotFactory():
 
     def create_dot(self, graph):
         dot = graph.create_dot()
-        if type(dot) != str:
+        if not isinstance(dot, str):
             dot = dot.decode()
         # sadly pydot generates line wraps cutting between numbers
         return dot.replace('\\%s' % os.linesep, '').replace('\\\n', '')


### PR DESCRIPTION
Make sure to use isinstance.

This should make it compatible with older flake8 in Ubuntu 22.04 and newer flake8 in Ubuntu 24.04