### PR TITLE
Handle empty dotcode nodes.

### DIFF
--- a/qt_dotgraph/src/qt_dotgraph/dot_to_qt.py
+++ b/qt_dotgraph/src/qt_dotgraph/dot_to_qt.py
@@ -257,9 +257,6 @@ class DotToQtGenerator():
         if isinstance(graph, list):
             graph = graph[0]
 
-        # graph = pygraphviz.AGraph(string=self._current_dotcode, strict=False, directed=True)
-        # graph.layout(prog='dot')
-
         nodes = self.parse_nodes(graph, highlight_level, scene=scene)
         edges = self.parse_edges(graph, nodes, highlight_level, same_label_siblings, scene=scene)
         return nodes, edges
@@ -281,6 +278,8 @@ class DotToQtGenerator():
             subgraph.nodes_iter = subgraph.get_node_list
             nodes[subgraph.get_name()] = subgraph_nodeitem
             for node in subgraph.nodes_iter():
+                if node.get_name() == r'"\n"':
+                    continue
                 # hack required by pydot
                 if node.get_name() in ('graph', 'node', 'empty'):
                     continue
@@ -288,6 +287,8 @@ class DotToQtGenerator():
                     self.getNodeItemForNode(node, highlight_level, scene=scene)
         for node in graph.nodes_iter():
             # hack required by pydot
+            if node.get_name() == r'"\n"':
+                continue
             if node.get_name() in ('graph', 'node', 'empty'):
                 continue
             nodes[node.get_name()] = self.getNodeItemForNode(node, highlight_level, scene=scene)


### PR DESCRIPTION
Modern versions of pydot can end up returning nodes corresponding to the empty string, i.e. "\n".  Make sure to ignore nodes of this kind, as that is a new behavior.