### PR TITLE
Skip running the tests on Windows Debug.

### DIFF
--- a/qt_dotgraph/test/dot_to_qt_test.py
+++ b/qt_dotgraph/test/dot_to_qt_test.py
@@ -34,6 +34,7 @@
 # This file does not pass flake8 due to the raw string literals below.
 # flake8: noqa
 
+import importlib.machinery
 import subprocess
 import sys
 import unittest
@@ -43,10 +44,12 @@ try:
     from qt_dotgraph.dot_to_qt import DotToQtGenerator, get_unquoted
     qt_import_failed = False
 except ImportError:
-    # If we are on Windows Debug, skip running these tests because we do not have the debug
-    # libraries available for PyQt.  Note that we can't directly fail here (as import
-    # failures cause pytest failures), so we just mark the situation and skip below.
-    if sys.platform == 'win32' and sys.executable.endswith('python_d.exe'):
+    # If this is running on a Python Windows interpreter built in debug mode, skip running tests
+    # because we do not have the debug libraries available for PyQt.  It is surprisingly tricky to
+    # discover whether the current interpreter was built in debug mode (note that this is different
+    # than running the interpreter in debug mode, i.e. PYTHONDEBUG=1).  The only non-deprecated way
+    # we've found is to look for _d.pyd in the extension suffixes, so that is what we do here.
+    if sys.platform == 'win32' and '_d.pyd' in importlib.machinery.EXTENSION_SUFFIXES:
         qt_import_failed = True
     else:
         raise

--- a/qt_dotgraph/test/dot_to_qt_test.py
+++ b/qt_dotgraph/test/dot_to_qt_test.py
@@ -38,8 +38,18 @@ import subprocess
 import sys
 import unittest
 
-from python_qt_binding.QtWidgets import QApplication
-from qt_dotgraph.dot_to_qt import DotToQtGenerator, get_unquoted
+try:
+    from python_qt_binding.QtWidgets import QApplication
+    from qt_dotgraph.dot_to_qt import DotToQtGenerator, get_unquoted
+    qt_import_failed = False
+except ImportError:
+    # If we are on Windows Debug, skip running these tests because we do not have the debug
+    # libraries available for PyQt.  Note that we can't directly fail here (as import
+    # failures cause pytest failures), so we just mark the situation and skip below.
+    if sys.platform == 'win32' and sys.executable.endswith('python_d.exe'):
+        qt_import_failed = True
+    else:
+        raise
 
 
 def check_x_server():
@@ -54,6 +64,7 @@ def check_x_server():
     return p.returncode == 0
 
 
+@unittest.skipIf(qt_import_failed, 'Skipping test on Windows Debug')
 class DotToQtGeneratorTest(unittest.TestCase):
 
     DOT_CODE = r'''


### PR DESCRIPTION
When we run CI on Windows Debug, Python expects to be able to find compiled libraries with an extra _d in their filename that contains the debugging ABI.

However, we don't currently have a debug library available for PyQt5, and thus when running under Windows Debug, the tests cannot succeed. While we could build a debug library for PyQt5, that is actually a massive undertaking. Instead, just skip these tests when we are on Windows Debug. While that loses us a bit of coverage, it won't matter much; we are still testing this on Windows (Release) and on Linux.

The way in which this patch determines that this is a Windows Debug interpreter is a little chintzy. It just uses the fact that the binary is named python_d.exe to discover that. I couldn't find another way to tell if this was a debug interpreter, but I am open to other ideas.