### PR TITLE
Bump cmake_minimum_required to avoid deprecation

### DIFF
--- a/qt_dotgraph/CMakeLists.txt
+++ b/qt_dotgraph/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.5)
 project(qt_dotgraph)
 
 find_package(catkin REQUIRED)

--- a/qt_gui/CMakeLists.txt
+++ b/qt_gui/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.5)
 project(qt_gui)
 
 find_package(catkin REQUIRED)

--- a/qt_gui_app/CMakeLists.txt
+++ b/qt_gui_app/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.5)
 project(qt_gui_app)
 
 find_package(catkin REQUIRED)

--- a/qt_gui_core/CMakeLists.txt
+++ b/qt_gui_core/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.5)
 project(qt_gui_core)
 find_package(catkin REQUIRED)
 catkin_metapackage()

--- a/qt_gui_cpp/CMakeLists.txt
+++ b/qt_gui_cpp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.5)
 project(qt_gui_cpp)
 
 find_package(catkin REQUIRED COMPONENTS cmake_modules pluginlib)

--- a/qt_gui_py_common/CMakeLists.txt
+++ b/qt_gui_py_common/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.5)
 project(qt_gui_py_common)
 
 find_package(catkin REQUIRED)


### PR DESCRIPTION
Noetic will be EOL very soon and it was already discussed what last changes would be worthwhile.
This was done in [Discourse](https://discourse.ros.org/t/ros-noetic-end-of-life-may-31-2025/43160/4) .
One point was the cmake_minimum_required version because <3.5 is deprecated in newer CMake version.