### PR TITLE
Use 3 term cmake version for metapackage

### DIFF
--- a/qt_gui_core/CMakeLists.txt
+++ b/qt_gui_core/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.5.0)
 project(qt_gui_core)
 find_package(catkin REQUIRED)
 catkin_metapackage()


### PR DESCRIPTION
Fixes:

```
Invalid metapackage at path '/usr/local/google/home/sloretz/ws/noetic/mega-bloom/src/qt_gui_core/qt_gui_core':
  Metapackage 'qt_gui_core': Invalid CMakeLists.txt
Expected:
<<<cmake_minimum_required(VERSION <version x.y.z>)
project(qt_gui_core)
find_package(catkin REQUIRED)
catkin_metapackage()
>>>
Got:
<<<cmake_minimum_required(VERSION 3.5)
project(qt_gui_core)
find_package(catkin REQUIRED)
catkin_metapackage()
>>>

See requirements for metapackages: http://ros.org/reps/rep-0127.html#metapackage
```