### PR TITLE
Fix setupTools deprecations

### DIFF
--- a/qt_dotgraph/setup.py
+++ b/qt_dotgraph/setup.py
@@ -20,7 +20,6 @@ setup(
     keywords=['ROS'],
     classifiers=[
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: BSD License',
         'Programming Language :: Python',
         'Topic :: Software Development',
     ],
@@ -28,5 +27,9 @@ setup(
         'qt_dotgraph provides helpers to work with dot graphs.'
     ),
     license='BSD',
-    tests_require=['pytest'],
+    extras_require={
+        'test': [
+            'pytest',
+        ],
+    },
 )


### PR DESCRIPTION
FIX:

#UserWarning: Unknown distribution option: 'tests_require'

and

#SetuptoolsDeprecationWarning: License classifiers are deprecated. !!