### PR TITLE
Ignore case when asserting snippet presence in tests

### DIFF
--- a/qt_dotgraph/test/pydot_factory_test.py
+++ b/qt_dotgraph/test/pydot_factory_test.py
@@ -112,4 +112,6 @@ class PyDotFactoryTest(unittest.TestCase):
         # get rid of version specific whitespaces
         result = re.sub('[\n\t\r ]+', ' ', result)
         for sn in snippets:
-            self.assertTrue(sn in result, '%s \nmissing in\n %s' % (sn, result))
+            self.assertTrue(
+                sn.lower() in result.lower(),
+                '%s \nmissing in\n %s' % (sn, result))


### PR DESCRIPTION
In PyDot 3.0.0 and newer, booleans are no longer capitalized in the output, which makes this assert fail.

I don't believe that case mismatch is really something that we're concerned with in this test, so rather than special logic to detect the pydot version, we can just perform the checks case-insensitive.

Ubuntu Resolute and RHEL 10 both include PyDot versions newer than 3.0.0.