### PR TITLE
Update qt_gui_core to package.xml version 2.

### DIFF
--- a/qt_gui_core/package.xml
+++ b/qt_gui_core/package.xml
@@ -1,4 +1,4 @@
-<package>
+<package format="2">
   <name>qt_gui_core</name>
   <version>2.10.2</version>
   <description>
@@ -7,18 +7,17 @@
   <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
   <license>BSD</license>
 
-  <url type="website">http://ros.org/wiki/qt_gui_core</url>
   <url type="repository">https://github.com/ros-visualization/qt_gui_core</url>
   <url type="bugtracker">https://github.com/ros-visualization/qt_gui_core/issues</url>
   <author>Dirk Thomas</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <run_depend version_gte="0.3.0">qt_dotgraph</run_depend>
-  <run_depend version_gte="0.3.0">qt_gui</run_depend>
-  <run_depend version_gte="0.3.0">qt_gui_app</run_depend>
-  <run_depend version_gte="0.3.0">qt_gui_cpp</run_depend>
-  <run_depend version_gte="0.3.0">qt_gui_py_common</run_depend>
+  <exec_depend version_gte="0.3.0">qt_dotgraph</exec_depend>
+  <exec_depend version_gte="0.3.0">qt_gui</exec_depend>
+  <exec_depend version_gte="0.3.0">qt_gui_app</exec_depend>
+  <exec_depend version_gte="0.3.0">qt_gui_cpp</exec_depend>
+  <exec_depend version_gte="0.3.0">qt_gui_py_common</exec_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
Somehow throughout 12 years of ROS 2 development, this single package.xml is still using package.xml version 1. I think that can only happen here because it is a
meta-package; I'm fairly certain we have tests for this elsewhere.

Regardless, update this to a package.xml version 2 package.