### PR TITLE
Removed Qt5 calls to Qt6

### DIFF
--- a/qt_gui/package.xml
+++ b/qt_gui/package.xml
@@ -16,8 +16,8 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <build_depend>qt5-qmake</build_depend>
-  <build_depend>python3-qt5-bindings</build_depend>
+  <build_depend>qt6-qmake</build_depend>
+  <build_depend>python3-qt6-bindings</build_depend>
 
   <exec_depend>ament_index_python</exec_depend>
   <exec_depend>python_qt_binding</exec_depend>

--- a/qt_gui/package.xml
+++ b/qt_gui/package.xml
@@ -16,7 +16,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <build_depend>qt6-qmake</build_depend>
+  <build_depend>qmake6</build_depend>
   <build_depend>python3-qt-bindings</build_depend>
 
   <exec_depend>ament_index_python</exec_depend>

--- a/qt_gui/package.xml
+++ b/qt_gui/package.xml
@@ -17,7 +17,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <build_depend>qt6-qmake</build_depend>
-  <build_depend>python3-qt6-bindings</build_depend>
+  <build_depend>python3-qt-bindings</build_depend>
 
   <exec_depend>ament_index_python</exec_depend>
   <exec_depend>python_qt_binding</exec_depend>

--- a/qt_gui_cpp/CMakeLists.txt
+++ b/qt_gui_cpp/CMakeLists.txt
@@ -53,7 +53,7 @@ target_include_directories(${PROJECT_NAME} PUBLIC
 target_link_libraries(${PROJECT_NAME}
   ${QT_QTCORE_LIBRARY}
   ${QT_QTGUI_LIBRARY}
-  Qt5::Widgets
+  Qt6::Widgets
   pluginlib::pluginlib
   tinyxml2::tinyxml2)
 

--- a/qt_gui_cpp/CMakeLists.txt
+++ b/qt_gui_cpp/CMakeLists.txt
@@ -20,7 +20,7 @@ if(WIN32)
 endif()
 
 find_package(pluginlib REQUIRED)
-find_package(Qt5 REQUIRED COMPONENTS Widgets)
+find_package(Qt6 REQUIRED COMPONENTS Core Gui Widgets)
 find_package(TinyXML2 REQUIRED)
 
 ament_python_install_package(${PROJECT_NAME}
@@ -43,7 +43,7 @@ set(qt_gui_cpp_HDRS
   include/qt_gui_cpp/plugin_context.hpp
 )
 
-qt5_wrap_cpp(qt_gui_cpp_MOCS ${qt_gui_cpp_HDRS})
+qt6_wrap_cpp(qt_gui_cpp_MOCS ${qt_gui_cpp_HDRS})
 
 add_library(${PROJECT_NAME} SHARED ${qt_gui_cpp_SRCS} ${qt_gui_cpp_MOCS})
 target_include_directories(${PROJECT_NAME} PUBLIC
@@ -51,9 +51,7 @@ target_include_directories(${PROJECT_NAME} PUBLIC
   "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
 
 target_link_libraries(${PROJECT_NAME}
-  ${QT_QTCORE_LIBRARY}
-  ${QT_QTGUI_LIBRARY}
-  Qt6::Widgets
+  ${qt_gui_cpp_QT_LIBRARIES}
   pluginlib::pluginlib
   tinyxml2::tinyxml2)
 

--- a/qt_gui_cpp/CMakeLists.txt
+++ b/qt_gui_cpp/CMakeLists.txt
@@ -21,6 +21,10 @@ endif()
 
 find_package(pluginlib REQUIRED)
 find_package(Qt6 REQUIRED COMPONENTS Core Gui Widgets)
+set(qt_gui_cpp_QT_LIBRARIES
+  Qt6::Core
+  Qt6::Gui
+  Qt6::Widgets)
 find_package(TinyXML2 REQUIRED)
 
 ament_python_install_package(${PROJECT_NAME}

--- a/qt_gui_cpp/package.xml
+++ b/qt_gui_cpp/package.xml
@@ -18,7 +18,7 @@
   <build_depend>pkg-config</build_depend>
   <build_depend version_gte="1.9.23">pluginlib</build_depend>
   <build_depend version_gte="0.3.0">python_qt_binding</build_depend>
-  <build_depend>qt5-qmake</build_depend>
+  <build_depend>qt6-qmake</build_depend>
   <build_depend>qtbase5-dev</build_depend>
   <build_depend>tinyxml2</build_depend>
 

--- a/qt_gui_cpp/package.xml
+++ b/qt_gui_cpp/package.xml
@@ -18,7 +18,7 @@
   <build_depend>pkg-config</build_depend>
   <build_depend version_gte="1.9.23">pluginlib</build_depend>
   <build_depend version_gte="0.3.0">python_qt_binding</build_depend>
-  <build_depend>qt6-qmake</build_depend>
+  <build_depend>qmake6</build_depend>
   <build_depend>qtbase5-dev</build_depend>
   <build_depend>tinyxml2</build_depend>
 

--- a/qt_gui_cpp/src/qt_gui_cpp/plugin_provider.cpp
+++ b/qt_gui_cpp/src/qt_gui_cpp/plugin_provider.cpp
@@ -43,7 +43,7 @@ PluginProvider::~PluginProvider()
 
 QMap<QString, QString> PluginProvider::discover(QObject * discovery_data)
 {
-  QMultiMap<QString, QString> plugins;
+  QMap<QString, QString> plugins;
   QList<PluginDescriptor *> descriptors = discover_descriptors(discovery_data);
   for (QList<PluginDescriptor *>::iterator it = descriptors.begin(); it != descriptors.end();
     it++)
@@ -51,7 +51,7 @@ QMap<QString, QString> PluginProvider::discover(QObject * discovery_data)
     // extract plugin descriptor dictionary
     PluginDescriptor * descriptor = *it;
     QMap<QString, QString> plugin = descriptor->toDictionary();
-    plugins.unite(plugin);
+    plugins.insert(plugin);
     delete descriptor;
   }
   return plugins;

--- a/qt_gui_cpp/src/qt_gui_cpp_shiboken/CMakeLists.txt
+++ b/qt_gui_cpp/src/qt_gui_cpp_shiboken/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(Qt5Widgets REQUIRED)
+find_package(Qt6Widgets REQUIRED)
 set(qt_gui_cpp_shiboken_QT_COMPONENTS
   QtCore
   QtGui
@@ -52,7 +52,7 @@ if(shiboken_helper_FOUND)
     list(APPEND qt_gui_cpp_BINDINGS "shiboken")
     set(qt_gui_cpp_BINDINGS "${qt_gui_cpp_BINDINGS}" PARENT_SCOPE)
 
-    set(QT_INCLUDE_DIR "${Qt5Widgets_INCLUDE_DIRS}")
+    set(QT_INCLUDE_DIR "${Qt6Widgets_INCLUDE_DIRS}")
     shiboken_generator(
       libqt_gui_cpp
       global.h


### PR DESCRIPTION
Fix: #326



One thing I'm not sure what to do is with ` <build_depend>qt6-qmake</build_depend>`, this approach works but looking at google, they said the new standard for `Qt6` is `Cmake` instead of `qmake`


[![Build Status](https://ci.ros2.org/job/test_ci_linux-aarch64/97/badge/icon)](https://ci.ros2.org/job/test_ci_linux-aarch64/97/)

```
rqt_gui_cpp (stderr)
12:54:37 --- stderr: rqt_gui_cpp
12:54:37 CMake Error at /home/jenkins-agent/workspace/test_ci_linux-aarch64/ws/install/qt_gui_cpp/share/qt_gui_cpp/cmake/export_qt_gui_cppExport.cmake:61 (set_target_properties):
12:54:37   The link interface of target "qt_gui_cpp::qt_gui_cpp" contains:
12:54:37 
12:54:37     Qt6::Core
12:54:37 
12:54:37   but the target was not found.  Possible reasons include:
12:54:37 
12:54:37     * There is a typo in the target name.
12:54:37     * A find_package call is missing for an IMPORTED target.
12:54:37     * An ALIAS target is missing.
12:54:37 
12:54:37 Call Stack (most recent call first):
12:54:37   /home/jenkins-agent/workspace/test_ci_linux-aarch64/ws/install/qt_gui_cpp/share/qt_gui_cpp/cmake/ament_cmake_export_targets-extras.cmake:9 (include)
12:54:37   /home/jenkins-agent/workspace/test_ci_linux-aarch64/ws/install/qt_gui_cpp/share/qt_gui_cpp/cmake/qt_gui_cppConfig.cmake:41 (include)
12:54:37   CMakeLists.txt:30 (find_package)
12:54:37 
12:54:37 
12:54:37 CMake Generate step failed.  Build files cannot be regenerated correctly.
12:54:37 ---
```
### Update
Apparently there is a bug regarding qt6 with cmake: https://qt-project.atlassian.net/browse/QTBUG-97615
I probably will leave this issue to someone with more experience