### PR TITLE
switch between qt5 and 6

### DIFF
--- a/qt_gui_cpp/CMakeLists.txt
+++ b/qt_gui_cpp/CMakeLists.txt
@@ -20,7 +20,10 @@ if(WIN32)
 endif()
 
 find_package(pluginlib REQUIRED)
-find_package(Qt5 REQUIRED COMPONENTS Widgets)
+find_package(Qt6 COMPONENTS Widgets QUIET)
+if (NOT Qt6_FOUND)
+    find_package(Qt5 COMPONENTS Widgets REQUIRED)
+endif()
 find_package(TinyXML2 REQUIRED)
 
 ament_python_install_package(${PROJECT_NAME}
@@ -43,19 +46,32 @@ set(qt_gui_cpp_HDRS
   include/qt_gui_cpp/plugin_context.hpp
 )
 
-qt5_wrap_cpp(qt_gui_cpp_MOCS ${qt_gui_cpp_HDRS})
+if (Qt6_FOUND)
+  qt6_wrap_cpp(qt_gui_cpp_MOCS ${qt_gui_cpp_HDRS})
+else()
+  qt5_wrap_cpp(qt_gui_cpp_MOCS ${qt_gui_cpp_HDRS})
+endif()
 
 add_library(${PROJECT_NAME} SHARED ${qt_gui_cpp_SRCS} ${qt_gui_cpp_MOCS})
 target_include_directories(${PROJECT_NAME} PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>"
   "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
 
-target_link_libraries(${PROJECT_NAME}
-  ${QT_QTCORE_LIBRARY}
-  ${QT_QTGUI_LIBRARY}
-  Qt5::Widgets
-  pluginlib::pluginlib
-  tinyxml2::tinyxml2)
+if (Qt6_FOUND)
+  target_link_libraries(${PROJECT_NAME}
+    ${QT_QTCORE_LIBRARY}
+    ${QT_QTGUI_LIBRARY}
+    Qt6::Widgets
+    pluginlib::pluginlib
+    tinyxml2::tinyxml2)
+else()
+  target_link_libraries(${PROJECT_NAME}
+    ${QT_QTCORE_LIBRARY}
+    ${QT_QTGUI_LIBRARY}
+    Qt5::Widgets
+    pluginlib::pluginlib
+    tinyxml2::tinyxml2)endif()
+endif()
 
 add_subdirectory(src/qt_gui_cpp_shiboken)
 add_subdirectory(src/qt_gui_cpp_sip)


### PR DESCRIPTION
Attempt to fix https://ci.ros2.org/job/ci_linux-aarch64/21468 and https://ci.ros2.org/job/nightly_linux-aarch64_release/3526/. Supposed to be related to this PR: https://github.com/ros2/ci/pull/857/changes


I have had the experience that dev environments with both qt5 and qt6 don't play well together. This PR is currently only pointed towards qt_gui_cpp but if this works then it can be applied to the other cmakelist.txt too. 

```
CMake Error at /home/jenkins-agent/workspace/ci_linux-aarch64/ws/install/qt_gui_cpp/share/qt_gui_cpp/cmake/export_qt_gui_cppExport.cmake:61 (set_target_properties):
  The link interface of target "qt_gui_cpp::qt_gui_cpp" contains:

    Qt5::Widgets

  but the target was not found.  Possible reasons include:

    * There is a typo in the target name.
    * A find_package call is missing for an IMPORTED target.
    * An ALIAS target is missing.

Call Stack (most recent call first):
  /home/jenkins-agent/workspace/ci_linux-aarch64/ws/install/qt_gui_cpp/share/qt_gui_cpp/cmake/ament_cmake_export_targets-extras.cmake:9 (include)
  /home/jenkins-agent/workspace/ci_linux-aarch64/ws/install/qt_gui_cpp/share/qt_gui_cpp/cmake/qt_gui_cppConfig.cmake:41 (include)
  CMakeLists.txt:30 (find_package)
```