### PR TITLE
Export qt dependencies in package.xml

### DIFF
--- a/qt_gui_cpp/package.xml
+++ b/qt_gui_cpp/package.xml
@@ -22,8 +22,13 @@
   <build_depend>libqtwidgets</build_depend>
   <build_depend>tinyxml2</build_depend>
 
+  <build_export_depend>qt-base-dev</build_export_depend>
+  <build_export_depend>libqtwidgets</build_export_depend>
+
   <exec_depend version_gte="1.9.23">pluginlib</exec_depend>
   <exec_depend version_gte="0.3.0">qt_gui</exec_depend>
+  <exec_depend>qt-base-dev</exec_depend>
+  <exec_depend>libqtwidgets</exec_depend>
   <exec_depend>tinyxml2</exec_depend>
 
   <test_depend>ament_cmake_pytest</test_depend>


### PR DESCRIPTION
Attempt at fixing https://build.ros2.org/view/Rbin_uN64/job/Rbin_uN64__rqt_image_view__ubuntu_noble_amd64__binary/

Looks like when we introduced Qt6 support, we changed from a plain `target_link_libraries` signature to a keyword one using the `PUBLIC` keyword. This should make the exported target reference the Qt widgets target, and that causes downstream rqt_image to fail to build.

I think the change to use PUBLIC is probably correct because I see Qt includes in headers of qt_gui_cpp,  so I exported them here.