### PR TITLE
find_package(Qt...) in downstream packages

### DIFF
--- a/qt_gui_cpp/CMakeLists.txt
+++ b/qt_gui_cpp/CMakeLists.txt
@@ -21,7 +21,6 @@ endif()
 
 find_package(pluginlib REQUIRED)
 include(cmake/qt_gui_cpp-extras.cmake)
-find_package(Qt${qt_gui_cpp_USE_QT_MAJOR_VERSION} REQUIRED COMPONENTS Widgets Core)
 find_package(TinyXML2 REQUIRED)
 
 ament_python_install_package(${PROJECT_NAME}
@@ -84,9 +83,6 @@ install(
   DESTINATION include/${PROJECT_NAME}
 )
 
-if(${qt_gui_cpp_USE_QT_MAJOR_VERSION} GREATER "5")
-  ament_export_dependencies(Qt6)
-endif()
 ament_export_dependencies(pluginlib TinyXML2)
 ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
 

--- a/qt_gui_cpp/cmake/qt_gui_cpp-extras.cmake
+++ b/qt_gui_cpp/cmake/qt_gui_cpp-extras.cmake
@@ -29,3 +29,4 @@
 
 find_package(python_qt_binding QUIET)
 set(qt_gui_cpp_USE_QT_MAJOR_VERSION "${python_qt_binding_QT_MAJOR_VERSION}")
+find_package(Qt${qt_gui_cpp_USE_QT_MAJOR_VERSION} REQUIRED COMPONENTS Widgets Core)


### PR DESCRIPTION
One more attempt to fix https://build.ros2.org/view/Rbin_uN64/job/Rbin_uN64__rqt_image_view__ubuntu_noble_amd64__binary/161/consoleFull

We have to `find_package(Qt5)` with the same components in downstream packages in order to make the CMake targets available. Normally in ROS we do this with `ament_export_dependencies()`, but last I checked that doesn't support components. This does the `find_package()`ing in the extras file where it is included by qt_gui_cpp and anything downstream.